### PR TITLE
feat: add registerAdaptersSafe for idempotent adapter registration

### DIFF
--- a/hive_generator/example/build.yaml
+++ b/hive_generator/example/build.yaml
@@ -7,3 +7,4 @@ targets:
             - unnecessary_const
             - require_trailing_commas
             - document_ignores
+            - unused_element

--- a/hive_generator/example/lib/hive/hive_adapters.g.dart
+++ b/hive_generator/example/lib/hive/hive_adapters.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: unnecessary_const, require_trailing_commas, document_ignores
+// ignore_for_file: unnecessary_const, require_trailing_commas, document_ignores, unused_element
 
 part of 'hive_adapters.dart';
 

--- a/hive_generator/example/lib/hive/hive_registrar.g.dart
+++ b/hive_generator/example/lib/hive/hive_registrar.g.dart
@@ -2,7 +2,7 @@
 // Do not modify
 // Check in to version control
 
-// ignore_for_file: unnecessary_const, require_trailing_commas, document_ignores
+// ignore_for_file: unnecessary_const, require_trailing_commas, document_ignores, unused_element
 
 import 'package:hive_ce/hive.dart';
 import 'package:example/hive/hive_adapters.dart';
@@ -21,6 +21,19 @@ extension HiveRegistrar on HiveInterface {
     registerAdapter(IterableClassAdapter());
     registerAdapter(NamedImportsAdapter());
     registerAdapter(NullableTypesAdapter());
+  void registerAdaptersSafe() {
+    if (!Hive.isAdapterRegistered(Class1Adapter().typeId)) registerAdapter(Class1Adapter());
+    if (!Hive.isAdapterRegistered(Class2Adapter().typeId)) registerAdapter(Class2Adapter());
+    if (!Hive.isAdapterRegistered(ClassSpec1Adapter().typeId)) registerAdapter(ClassSpec1Adapter());
+    if (!Hive.isAdapterRegistered(ClassSpec2Adapter().typeId)) registerAdapter(ClassSpec2Adapter());
+    if (!Hive.isAdapterRegistered(ConstructorDefaultsAdapter().typeId)) registerAdapter(ConstructorDefaultsAdapter());
+    if (!Hive.isAdapterRegistered(EmptyClassAdapter().typeId)) registerAdapter(EmptyClassAdapter());
+    if (!Hive.isAdapterRegistered(Enum1Adapter().typeId)) registerAdapter(Enum1Adapter());
+    if (!Hive.isAdapterRegistered(EnumSpecAdapter().typeId)) registerAdapter(EnumSpecAdapter());
+    if (!Hive.isAdapterRegistered(IterableClassAdapter().typeId)) registerAdapter(IterableClassAdapter());
+    if (!Hive.isAdapterRegistered(NamedImportsAdapter().typeId)) registerAdapter(NamedImportsAdapter());
+    if (!Hive.isAdapterRegistered(NullableTypesAdapter().typeId)) registerAdapter(NullableTypesAdapter());
+    }
   }
 }
 
@@ -37,5 +50,18 @@ extension IsolatedHiveRegistrar on IsolatedHiveInterface {
     registerAdapter(IterableClassAdapter());
     registerAdapter(NamedImportsAdapter());
     registerAdapter(NullableTypesAdapter());
+  void registerAdaptersSafe() {
+    if (!Hive.isAdapterRegistered(Class1Adapter().typeId)) registerAdapter(Class1Adapter());
+    if (!Hive.isAdapterRegistered(Class2Adapter().typeId)) registerAdapter(Class2Adapter());
+    if (!Hive.isAdapterRegistered(ClassSpec1Adapter().typeId)) registerAdapter(ClassSpec1Adapter());
+    if (!Hive.isAdapterRegistered(ClassSpec2Adapter().typeId)) registerAdapter(ClassSpec2Adapter());
+    if (!Hive.isAdapterRegistered(ConstructorDefaultsAdapter().typeId)) registerAdapter(ConstructorDefaultsAdapter());
+    if (!Hive.isAdapterRegistered(EmptyClassAdapter().typeId)) registerAdapter(EmptyClassAdapter());
+    if (!Hive.isAdapterRegistered(Enum1Adapter().typeId)) registerAdapter(Enum1Adapter());
+    if (!Hive.isAdapterRegistered(EnumSpecAdapter().typeId)) registerAdapter(EnumSpecAdapter());
+    if (!Hive.isAdapterRegistered(IterableClassAdapter().typeId)) registerAdapter(IterableClassAdapter());
+    if (!Hive.isAdapterRegistered(NamedImportsAdapter().typeId)) registerAdapter(NamedImportsAdapter());
+    if (!Hive.isAdapterRegistered(NullableTypesAdapter().typeId)) registerAdapter(NullableTypesAdapter());
+    }
   }
 }

--- a/hive_generator/example/lib/types.g.dart
+++ b/hive_generator/example/lib/types.g.dart
@@ -1,6 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
 
-// ignore_for_file: unnecessary_const, require_trailing_commas, document_ignores
+// ignore_for_file: unnecessary_const, require_trailing_commas, document_ignores, unused_element
 
 part of 'types.dart';
 

--- a/hive_generator/lib/src/builder/registrar_builder.dart
+++ b/hive_generator/lib/src/builder/registrar_builder.dart
@@ -87,6 +87,16 @@ extension HiveRegistrar on HiveInterface {
     }
 
     buffer.write('''
+  void registerAdaptersSafe() {
+''');
+
+    for (final adapter in adapters) {
+      buffer.writeln(
+          '    if (!Hive.isAdapterRegistered($adapter().typeId)) registerAdapter($adapter());');
+    }
+
+    buffer.write('''
+    }
   }
 }
 
@@ -99,6 +109,16 @@ extension IsolatedHiveRegistrar on IsolatedHiveInterface {
     }
 
     buffer.write('''
+  void registerAdaptersSafe() {
+''');
+
+    for (final adapter in adapters) {
+      buffer.writeln(
+          '    if (!Hive.isAdapterRegistered($adapter().typeId)) registerAdapter($adapter());');
+    }
+
+    buffer.write('''
+    }
   }
 }
 ''');


### PR DESCRIPTION
### Summary

This PR introduces a new method `registerAdaptersSafe()` in both `HiveRegistrar` and `IsolatedHiveRegistrar` extensions generated by `hive_ce_generator`.

This method functions as a safer alternative to `registerAdapters()`, preventing runtime `HiveError`s when the same adapter is registered more than once. This is particularly useful in:

- Retry flows (e.g., during app startup)
- Multi-isolate setups
- Applications with dynamically reloaded state

---

### Implementation

- Generated `registerAdaptersSafe()` uses `Hive.isAdapterRegistered(adapter.typeId)` to guard each call to `registerAdapter(...)`.
- Preserves the existing `registerAdapters()` method for full backward compatibility.
- Automatically includes `unused_element` in the `// ignore_for_file:` comment to suppress analyzer warnings if `registerAdaptersSafe()` is unused.

Example generated output:
```dart
extension HiveRegistrar on HiveInterface {
  void registerAdapters() {
    registerAdapter(MyAdapter());
  }

  void registerAdaptersSafe() {
    if (!Hive.isAdapterRegistered(MyAdapter().typeId)) registerAdapter(MyAdapter());
  }
}
