### PR TITLE
Fix: import relative path within the registrar

### DIFF
--- a/hive_generator/lib/src/builder/registrar_builder.dart
+++ b/hive_generator/lib/src/builder/registrar_builder.dart
@@ -73,7 +73,8 @@ class RegistrarBuilder implements Builder {
     buffer.writeln("import 'package:hive_ce/hive.dart';");
 
     for (final uri in uris) {
-      buffer.writeln("import '$uri';");
+      final resultUri = getRelativePath(uri);
+      buffer.writeln("import '$resultUri';");
     }
 
     buffer.write('''
@@ -122,6 +123,15 @@ extension IsolatedHiveRegistrar on IsolatedHiveInterface {
         buildStep.allowedOutputs.single,
         buffer.toString(),
       );
+    }
+  }
+
+  String getRelativePath(String uri) {
+    Uri pathUri = Uri.parse(uri);
+    if (pathUri.scheme == 'package') {
+      return pathUri.pathSegments.skip(1).join('/');
+    } else {
+      return uri;
     }
   }
 }


### PR DESCRIPTION
I see the HiveRegistrar file is having the complete path in the import section which is creating a lint issue, so have applied a fix to shorten the URL and only keep the relative path.