### PR TITLE
Add retry and failure recovery logic to backend manager to protect

### DIFF
--- a/hive/lib/src/backend/js/native/backend_manager.dart
+++ b/hive/lib/src/backend/js/native/backend_manager.dart
@@ -12,6 +12,131 @@ class BackendManager implements BackendManagerInterface {
   /// TODO: Document this!
   IDBFactory? get indexedDB => window.self.indexedDB;
 
+  /// Opens database with timeout and proper event handling.
+  /// Returns null if open fails/times out (doesn't throw).
+  Future<IDBDatabase?> _tryOpenWithTimeout(
+    String databaseName,
+    int version,
+    void Function(IDBVersionChangeEvent)? onUpgradeNeeded,
+    Duration timeout,
+  ) async {
+    final completer = Completer<IDBDatabase>();
+
+    final request = indexedDB!.open(databaseName, version);
+
+    if (onUpgradeNeeded != null) {
+      request.onupgradeneeded = onUpgradeNeeded.toJS;
+    }
+
+    request.onsuccess = (Event e) {
+      if (!completer.isCompleted) {
+        completer.complete(request.result as IDBDatabase);
+      }
+    }.toJS;
+
+    request.onerror = (Event e) {
+      if (!completer.isCompleted) {
+        completer.completeError(request.error ?? 'Unknown error');
+      }
+    }.toJS;
+
+    // Handle blocked state - another connection is preventing upgrade
+    request.onblocked = (Event e) {
+      debugPrint('IndexedDB open blocked by existing connection');
+      if (!completer.isCompleted) {
+        completer.completeError('Database open blocked');
+      }
+    }.toJS;
+
+    try {
+      return await completer.future.timeout(timeout);
+    } catch (e) {
+      debugPrint('Database open failed: $e');
+      return null;
+    }
+  }
+
+  /// Attaches versionchange handler for logging. Does NOT close the connection
+  /// immediately - closing during pending async operations crashes Chrome.
+  /// The connection will close naturally when the page unloads.
+  // ignore: unused_element
+  void _attachVersionChangeHandler(IDBDatabase db) {
+    db.onversionchange = (Event e) {
+      debugPrint('Version change requested - connection will close on page unload');
+      // Don't call db.close() here - it crashes Chrome if initialize() is still running
+    }.toJS;
+  }
+
+  /// Opens IndexedDB with multi-stage recovery for stale connections.
+  /// This helps prevent crashes during page reloads in DDC development mode.
+  ///
+  /// Stage 1: Normal open with short timeout (3 attempts)
+  /// Stage 2: Version upgrade to force stale connections to close (3 attempts)
+  /// Throws HiveError with clear message if all attempts fail.
+  Future<IDBDatabase> _openDatabaseWithRecovery(
+    String databaseName,
+    int version,
+    void Function(IDBVersionChangeEvent)? onUpgradeNeeded,
+  ) async {
+    // Stage 1: Try normal open with short timeout (3 attempts)
+    for (int i = 0; i < 3; i++) {
+      debugPrint('Stage 1 attempt ${i + 1}: Normal open of $databaseName');
+      final db = await _tryOpenWithTimeout(
+        databaseName,
+        version,
+        onUpgradeNeeded,
+        const Duration(seconds: 3),
+      );
+      if (db != null) {
+        return db;
+      }
+      await Future.delayed(Duration(milliseconds: 200 * (i + 1)));
+    }
+
+    // Stage 2: Try version upgrade to force stale connections to close
+    debugPrint('Stage 2: Attempting version upgrade to break stale connections');
+
+    // Get current version first (with timeout to avoid hanging)
+    int currentVersion = version;
+    try {
+      final probeDb = await _tryOpenWithTimeout(
+        databaseName,
+        version,
+        null,
+        const Duration(seconds: 2),
+      );
+      if (probeDb != null) {
+        currentVersion = probeDb.version;
+        probeDb.close();
+      }
+    } catch (e) {
+      debugPrint('Could not probe version: $e');
+    }
+
+    // Try opening with incremented version
+    for (int i = 0; i < 3; i++) {
+      final newVersion = currentVersion + i + 1;
+      debugPrint('Stage 2 attempt ${i + 1}: Opening with version $newVersion');
+      final db = await _tryOpenWithTimeout(
+        databaseName,
+        newVersion,
+        onUpgradeNeeded,
+        const Duration(seconds: 5),
+      );
+      if (db != null) {
+        return db;
+      }
+      await Future.delayed(const Duration(milliseconds: 500));
+    }
+
+    // All recovery attempts failed - throw clear error
+    throw HiveError(
+      'Failed to open IndexedDB "$databaseName" after all recovery attempts. '
+      'A stale connection may be blocking access. '
+      'Try clearing browser data or restarting the browser.',
+    );
+  }
+
   @override
   Future<StorageBackend> open(
     String name,
@@ -24,22 +149,23 @@ class BackendManager implements BackendManagerInterface {
     final databaseName = collection ?? name;
     final objectStoreName = collection == null ? 'box' : name;
 
-    final request = indexedDB!.open(databaseName, 1);
-    request.onupgradeneeded = (IDBVersionChangeEvent e) {
-      final db = (e.target as IDBOpenDBRequest).result as IDBDatabase;
-      if (!db.objectStoreNames.contains(objectStoreName)) {
-        db.createObjectStore(objectStoreName);
-      }
-    }.toJS;
-    var db = await request.asFuture<IDBDatabase>();
+    IDBDatabase db;
 
-    // in case the objectStore is not contained, re-open the db and
-    // update version
-    if (!db.objectStoreNames.contains(objectStoreName)) {
-      debugPrint(
-        'Creating objectStore $objectStoreName in database $databaseName...',
+    if (crashRecovery) {
+      // Use multi-stage recovery for resilient opening
+      db = await _openDatabaseWithRecovery(
+        databaseName,
+        1,
+        (IDBVersionChangeEvent e) {
+          final db = (e.target as IDBOpenDBRequest).result as IDBDatabase;
+          if (!db.objectStoreNames.contains(objectStoreName)) {
+            db.createObjectStore(objectStoreName);
+          }
+        },
       );
-      final request = indexedDB!.open(databaseName, db.version + 1);
+    } else {
+      // Original behavior without retry
+      final request = indexedDB!.open(databaseName, 1);
       request.onupgradeneeded = (IDBVersionChangeEvent e) {
         final db = (e.target as IDBOpenDBRequest).result as IDBDatabase;
         if (!db.objectStoreNames.contains(objectStoreName)) {
@@ -47,6 +173,36 @@ class BackendManager implements BackendManagerInterface {
         }
       }.toJS;
       db = await request.asFuture<IDBDatabase>();
+    }
+
+    // in case the objectStore is not contained, re-open the db and
+    // update version
+    if (!db.objectStoreNames.contains(objectStoreName)) {
+      debugPrint(
+        'Creating objectStore $objectStoreName in database $databaseName...',
+      );
+
+      if (crashRecovery) {
+        db = await _openDatabaseWithRecovery(
+          databaseName,
+          db.version + 1,
+          (IDBVersionChangeEvent e) {
+            final db = (e.target as IDBOpenDBRequest).result as IDBDatabase;
+            if (!db.objectStoreNames.contains(objectStoreName)) {
+              db.createObjectStore(objectStoreName);
+            }
+          },
+        );
+      } else {
+        final request = indexedDB!.open(databaseName, db.version + 1);
+        request.onupgradeneeded = (IDBVersionChangeEvent e) {
+          final db = (e.target as IDBOpenDBRequest).result as IDBDatabase;
+          if (!db.objectStoreNames.contains(objectStoreName)) {
+            db.createObjectStore(objectStoreName);
+          }
+        }.toJS;
+        db = await request.asFuture<IDBDatabase>();
+      }
     }
 
     debugPrint('Got object store $objectStoreName in database $databaseName.');


### PR DESCRIPTION
We've been trying to figure out a vague and difficult issue with our Flutter Web Application. 

# User Stories

When you load the application it would start fine. Then when you navigated to the same page (or to another page on the same site) by clicking the address bar and pressing enter it would crash the entire browser. Like, full-on crash complete with a very unhappy smiley face. 

No logs other than the dev tools saying "The Renderer is Gone" and Flutter saying "The Target has Crashed".

Alternatively, instead of navigating you click refresh or do a soft or hard refresh of the page. It would either crash entirely like before, or it would sit on the Flutter loading screen indefinitely. 

Weirdly, in both scenarios, if you simply refresh the page or click in the address bar and press enter to navigate to the page, it would work fine. But then if you tried again the browser would enter a crashed state. So you could have this tick-tock crash cycle.

# What seems to be wrong

After a day of poking at this issue, we narrowed it down to Hive_CE. Specifically, opening Databases was causing the issue. This only happens on some machines and not others. More specifically, from what I can tell, this happens in Chrome on Linux based machines. (Seems to also impact web apps on Android)

As far as I can tell, when IndexedDB loads the databases for a tab in Chrome it pulls a lock on the databases. When you navigate to the same site or refresh the browser, it seems that the page begins reloading **before** the lock is fully released. IndexedDB doesn't let go of the lock until after Hive attempts to reestablish it on the page reload. This doesn't just cause hive to fail, but also causes the entire browser to explode in a fireworks of angry app testers.

# The Fix

After a day of messing around we landed on this PR for Hive which seems to resolve the issue almost entirely. It still has trouble on rare occasion, but I'm not sure that is hive's fault. Really, I don't think any of this is Hive's fault. But this mitigates the issue to the point where we feel it is acceptable.

Basically this implements try logic with wait timers to allow hive to pause app initialization until IndexedDB is ready.  It will try up to 5 times before failing.

Secondly, if Hive fails it will step back and send a signal to IndexedDB with a version upgrade basically telling it to give control to the new Hive instance so it can properly get going.

With this one-two punch Hive seems to initialize fine now. Usually just waiting 300ms on the first go and then assuming control of IndexedDB once the lock is released.

---

Have a look at what I did. I'm not an IndexedDB expert. But this seems to work reliably in my testing environment. And makes Hive much more resilient to the shenanigans from Chrome -- especially on Linux machines.