### PR TITLE
Add support for fast_immutable_collections and built_collection to adapter generator

### DIFF
--- a/hive_generator/example/lib/hive/hive_adapters.dart
+++ b/hive_generator/example/lib/hive/hive_adapters.dart
@@ -1,3 +1,5 @@
+import 'package:built_collection/built_collection.dart';
+import 'package:fast_immutable_collections/fast_immutable_collections.dart';
 import 'package:hive_ce/hive_ce.dart';
 import 'package:meta/meta.dart';
 
@@ -26,7 +28,29 @@ class ClassSpec2 {
   final Set<String> set;
   final List<String> list;
 
-  const ClassSpec2(this.value, this.value2, this.iterable, this.set, this.list);
+  final IList<String> iList;
+  final ISet<String> iSet;
+  final IMap<String, String> iMap;
+  final BuiltMap<String, BuiltMap<String, String>> iListList;
+
+  final BuiltList<String> builtList;
+  final BuiltSet<String> builtSet;
+  final BuiltMap<String, String> builtMap;
+
+  const ClassSpec2(
+    this.value,
+    this.value2,
+    this.iterable,
+    this.set,
+    this.list,
+    this.iList,
+    this.iSet,
+    this.iMap,
+    this.iListList,
+    this.builtList,
+    this.builtSet,
+    this.builtMap,
+  );
 }
 
 class ClassSpec3 {

--- a/hive_generator/example/lib/hive/hive_adapters.g.dart
+++ b/hive_generator/example/lib/hive/hive_adapters.g.dart
@@ -58,13 +58,27 @@ class ClassSpec2Adapter extends TypeAdapter<ClassSpec2> {
       (fields[2] as List).cast<String>(),
       (fields[3] as Set).cast<String>(),
       (fields[4] as List).cast<String>(),
+      (fields[5] as List).cast<String>().lockUnsafe,
+      (fields[6] as Set).cast<String>().lockUnsafe,
+      (fields[7] as Map).cast<String, String>().lockUnsafe,
+      (fields[11] as Map)
+          .map(
+            (dynamic k, dynamic v) => MapEntry(
+              k as String,
+              (v as Map).cast<String, String>().build(),
+            ),
+          )
+          .build(),
+      (fields[8] as List).cast<String>().build(),
+      (fields[9] as Set).cast<String>().build(),
+      (fields[10] as Map).cast<String, String>().build(),
     );
   }
 
   @override
   void write(BinaryWriter writer, ClassSpec2 obj) {
     writer
-      ..writeByte(5)
+      ..writeByte(12)
       ..writeByte(0)
       ..write(obj.value)
       ..writeByte(1)
@@ -74,7 +88,21 @@ class ClassSpec2Adapter extends TypeAdapter<ClassSpec2> {
       ..writeByte(3)
       ..write(obj.set)
       ..writeByte(4)
-      ..write(obj.list);
+      ..write(obj.list)
+      ..writeByte(5)
+      ..write(obj.iList.unlockView)
+      ..writeByte(6)
+      ..write(obj.iSet.unlockView)
+      ..writeByte(7)
+      ..write(obj.iMap.unlockView)
+      ..writeByte(8)
+      ..write(obj.builtList.asList())
+      ..writeByte(9)
+      ..write(obj.builtSet.asSet())
+      ..writeByte(10)
+      ..write(obj.builtMap.asMap())
+      ..writeByte(11)
+      ..write(obj.iListList.map((k, v) => MapEntry(k, v.asMap())).asMap());
   }
 
   @override

--- a/hive_generator/example/lib/hive/hive_adapters.g.yaml
+++ b/hive_generator/example/lib/hive/hive_adapters.g.yaml
@@ -13,7 +13,7 @@ types:
         index: 1
   ClassSpec2:
     typeId: 51
-    nextIndex: 5
+    nextIndex: 12
     fields:
       value:
         index: 0
@@ -25,6 +25,20 @@ types:
         index: 3
       list:
         index: 4
+      iList:
+        index: 5
+      iSet:
+        index: 6
+      iMap:
+        index: 7
+      builtList:
+        index: 8
+      builtSet:
+        index: 9
+      builtMap:
+        index: 10
+      iListList:
+        index: 11
   EnumSpec:
     typeId: 52
     nextIndex: 2

--- a/hive_generator/example/pubspec.yaml
+++ b/hive_generator/example/pubspec.yaml
@@ -2,6 +2,8 @@ name: example
 dependencies:
   hive_ce: any
   meta: ^1.14.0
+  fast_immutable_collections: ^11.1.0
+  built_collection: ^5.1.1
 dev_dependencies:
   rexios_lints: ^17.0.2
   build_runner: ^2.5.4


### PR DESCRIPTION
This PR introduces support for generating adapters for classes containing fields from fast_immutable_collections (IList, ISet, IMap) and built_collection (BuiltList, BuiltSet, BuiltMap).

__Changes:__
- Updated ClassAdapterBuilder to recognize and handle ImmutableCollection and BuiltCollection types.
- Added logic to correctly serialize and deserialize these collections by converting them during read/write operations (locking/unlocking).
- Updated the example project to include test cases verifying support for these new types.