### PR TITLE
Rename subDir to dir in initFlutter, treat as relative or absolute

### DIFF
--- a/hive_flutter/lib/src/hive_extensions.dart
+++ b/hive_flutter/lib/src/hive_extensions.dart
@@ -6,15 +6,15 @@ import 'package:hive_ce_flutter/src/wrapper/path.dart' as path_helper;
 
 /// Flutter extensions for Hive.
 extension HiveX on HiveInterface {
-  /// Initializes Hive with the path from [getApplicationDocumentsDirectory].
+  /// Initializes Hive with the path from [getApplicationDocumentsDirectory], or as an absolute path.
   ///
-  /// You can provide a [subDir] where the boxes should be stored.
+  /// You can provide a [dir] where the boxes should be stored.
   ///
   /// Also registers the flutter type adapters
   /// - [colorAdapterTypeId] - The type id for the color adapter (default: 200)
   /// - [timeOfDayAdapterTypeId] - The type id for the time of day adapter (default: 201)
   Future<void> initFlutter([
-    String? subDir,
+    String? dir,
     HiveStorageBackendPreference backendPreference =
         HiveStorageBackendPreference.native,
     int? colorAdapterTypeId,
@@ -24,8 +24,18 @@ extension HiveX on HiveInterface {
 
     String? path;
     if (!kIsWeb) {
-      final appDir = await getApplicationDocumentsDirectory();
-      path = path_helper.join(appDir.path, subDir);
+      // join accepts the latter arguments as nullable so it is safe
+      // to consider it "relative" even in that case. If the user wants an
+      // absolute path pointing to the base of a well-defined
+      // path (including one with built-in dart support),
+      // different from getApplicationDocumentsDirectory,
+      // then they should pass that directory in.
+      if (dir == null || path_helper.isRelative(dir)) {
+        final appDir = await getApplicationDocumentsDirectory();
+        path = path_helper.join(appDir.path, dir);
+      } else {
+        path = dir;
+      }
     }
 
     init(


### PR DESCRIPTION
The concept here is mostly related to wanting more control over where the hive files are actually stored. Most likely the user would be choosing a dart built-in directory, but in the spirit of giving power back to the user, it seems simplest to base their decision on whether or not the path is relative (and continuing to treat the default `null` as relative for backwards compatibility/sanity).