### PR TITLE
Revert Zone.current.print logger workaround

### DIFF
--- a/hive/lib/src/util/logger.dart
+++ b/hive/lib/src/util/logger.dart
@@ -1,16 +1,5 @@
-import 'dart:async';
-
 import 'package:hive_ce/src/isolate/isolate_debug_name/isolate_debug_name.dart';
 import 'package:hive_ce/src/util/debug_utils.dart';
-
-// Dispatch through the current zone so that callers (most importantly tests)
-// can intercept log output via Zone print specifications. The top-level
-// `print` function relies on the global `printToZone` mutable field, which is
-// only set as a side-effect of `_rootFork`. When `printToZone` is null in the
-// current isolate, `print` writes directly to stdout, bypassing any zone
-// `print` handler installed by `runZoned` and causing race-condition flakes
-// in tests that use `captureOutput`.
-void _zonePrint(Object? message) => Zone.current.print('$message');
 
 /// Configures the logging behavior of Hive
 abstract class Logger {
@@ -35,35 +24,35 @@ abstract class Logger {
   /// Log a verbose message
   static void v(Object? message) {
     if (level.index > LoggerLevel.verbose.index) return;
-    _zonePrint(message);
+    print(message);
   }
 
   /// Log a debug message
   static void d(Object? message) {
     if (level.index > LoggerLevel.debug.index) return;
-    _zonePrint(message);
+    print(message);
   }
 
   /// Log an informational message
   static void i(Object? message) {
     if (level.index > LoggerLevel.info.index) return;
-    _zonePrint(message);
+    print(message);
   }
 
   /// Log a warning message
   static void w(Object? message) {
     if (level.index > LoggerLevel.warn.index) return;
-    _zonePrint(message);
+    print(message);
   }
 
   /// Log an error message
   static void e(Object? message) {
     if (level.index > LoggerLevel.error.index) return;
-    _zonePrint(message);
+    print(message);
   }
 
   /// Log a message for an event that should not be possible
-  static void wtf(Object? message) => _zonePrint(message);
+  static void wtf(Object? message) => print(message);
 }
 
 /// Logging levels for Hive


### PR DESCRIPTION
## Summary
- Reverts the `Zone.current.print` logger workaround added for flaky isolate tests
- [dart-lang/sdk#63408](https://github.com/dart-lang/sdk/issues/63408) is fixed, so top-level `print()` again honors `ZoneSpecification.print` after isolate thread migration

## Test plan
- [ ] CI passes, especially `isolate_test.dart` / hive VM tests that capture logger output via `runZoned`