### PR TITLE
Upgrade hive_ce_generator to analyzer 14

### DIFF
--- a/benchmarks/storage/pubspec.yaml
+++ b/benchmarks/storage/pubspec.yaml
@@ -2,7 +2,7 @@ name: hive_storage_benchmark
 publish_to: none
 
 environment:
-  sdk: ^3.9.0
+  sdk: ^3.11.0
 
 dependencies:
   json_annotation: ^4.9.0
@@ -13,7 +13,7 @@ dependencies:
   meta: ^1.14.0
 
 dev_dependencies:
-  rexios_lints: ^17.0.2
+  rexios_lints: ^18.1.0
   # build_runner: ^2.5.4 # TODO: Fix this
   json_serializable: ^6.8.0
   hive_ce_generator: any
@@ -25,4 +25,4 @@ dependency_overrides:
     path: ../../hive_generator
   build: ^4.0.0
   source_gen: ^4.0.0
-  analyzer: ^8.0.0
+  analyzer: ^14.0.0

--- a/hive/analysis_options.yaml
+++ b/hive/analysis_options.yaml
@@ -6,5 +6,6 @@ linter:
 
 plugins:
   rexios_lints:
+    version: ^17.0.2
     diagnostics:
       not_null_assertion: false

--- a/hive/example/pubspec.yaml
+++ b/hive/example/pubspec.yaml
@@ -5,12 +5,12 @@ dependencies:
   meta: ^1.17.0
 
 dev_dependencies:
-  rexios_lints: ^17.0.2
+  rexios_lints: ^18.1.0
   hive_ce_generator: any
   build_runner: ^2.5.4
 
 environment:
-  sdk: ^3.9.0
+  sdk: ^3.11.0
 
 dependency_overrides:
   hive_ce:

--- a/hive_flutter/example/pubspec.yaml
+++ b/hive_flutter/example/pubspec.yaml
@@ -3,7 +3,7 @@ publish_to: none
 version: 1.0.0+1
 
 environment:
-  sdk: ^3.9.0
+  sdk: ^3.11.0
 
 dependencies:
   flutter:
@@ -12,7 +12,7 @@ dependencies:
     path: ../../hive_flutter
 
 dev_dependencies:
-  rexios_lints: ^17.0.2
+  rexios_lints: ^18.1.0
   build_runner: ^2.5.4
   hive_ce_generator:
     path: ../../hive_generator

--- a/hive_flutter/example/pubspec.yaml
+++ b/hive_flutter/example/pubspec.yaml
@@ -20,6 +20,8 @@ dev_dependencies:
 dependency_overrides:
   hive_ce:
     path: ../../hive
+  # Flutter stable currently pins meta 1.18.0; analyzer 14 requires ^1.18.3.
+  meta: ^1.18.3
 
 flutter:
   uses-material-design: true

--- a/hive_generator/CHANGELOG.md
+++ b/hive_generator/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 1.11.3
 
 - Upgrades `analyzer` to `14.0.0`
+- Requires Dart SDK `^3.11.0`
+- Removes `source_helper` dependency
 
 ## 1.11.2
 

--- a/hive_generator/CHANGELOG.md
+++ b/hive_generator/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.11.3
+
+- Upgrades `analyzer` to `14.0.0`
+
 ## 1.11.2
 
 - Upgrades `analyzer` to `12.0.0`

--- a/hive_generator/analysis_options.yaml
+++ b/hive_generator/analysis_options.yaml
@@ -6,5 +6,6 @@ linter:
 
 plugins:
   rexios_lints:
+    version: ^18.1.0
     diagnostics:
       not_null_assertion: false

--- a/hive_generator/example/pubspec.yaml
+++ b/hive_generator/example/pubspec.yaml
@@ -3,12 +3,12 @@ dependencies:
   hive_ce: any
   meta: ^1.14.0
 dev_dependencies:
-  rexios_lints: ^17.0.2
+  rexios_lints: ^18.1.0
   build_runner: ^2.5.4
   hive_ce_generator:
     path: ..
 environment:
-  sdk: ^3.9.0
+  sdk: ^3.11.0
 dependency_overrides:
   hive_ce:
     path: ../../hive

--- a/hive_generator/lib/src/adapter_builder/class_adapter_builder.dart
+++ b/hive_generator/lib/src/adapter_builder/class_adapter_builder.dart
@@ -17,27 +17,34 @@ import 'package:hive_ce_generator/src/helper/type_helper.dart';
 /// TODO: Document this!
 class ClassAdapterBuilder extends AdapterBuilder {
   /// TODO: Document this!
-  const ClassAdapterBuilder(
-    super.cls,
-    super.getters,
-    super.setters,
-  );
+  const ClassAdapterBuilder(super.cls, super.getters, super.setters);
 
   /// [TypeChecker] for [HiveList].
-  final hiveListChecker =
-      const TypeChecker.typeNamed(HiveList, inPackage: 'hive_ce');
+  final hiveListChecker = const TypeChecker.typeNamed(
+    HiveList,
+    inPackage: 'hive_ce',
+  );
 
   /// [TypeChecker] for [Map].
-  final mapChecker =
-      const TypeChecker.typeNamed(Map, inPackage: 'core', inSdk: true);
+  final mapChecker = const TypeChecker.typeNamed(
+    Map,
+    inPackage: 'core',
+    inSdk: true,
+  );
 
   /// [TypeChecker] for [Set].
-  final setChecker =
-      const TypeChecker.typeNamed(Set, inPackage: 'core', inSdk: true);
+  final setChecker = const TypeChecker.typeNamed(
+    Set,
+    inPackage: 'core',
+    inSdk: true,
+  );
 
   /// [TypeChecker] for [Iterable].
-  final iterableChecker =
-      const TypeChecker.typeNamed(Iterable, inPackage: 'core', inSdk: true);
+  final iterableChecker = const TypeChecker.typeNamed(
+    Iterable,
+    inPackage: 'core',
+    inSdk: true,
+  );
 
   /// [TypeChecker] for [Uint8List].
   final uint8ListChecker = const TypeChecker.typeNamed(

--- a/hive_generator/lib/src/builder/registrar_builder.dart
+++ b/hive_generator/lib/src/builder/registrar_builder.dart
@@ -21,8 +21,9 @@ class RegistrarBuilder implements Builder {
     final uris = <String>[];
     final adapters = <String>[];
     Uri? registrarUri;
-    await for (final input
-        in buildStep.findAssets(Glob('**/*.hive_registrar.info'))) {
+    await for (final input in buildStep.findAssets(
+      Glob('**/*.hive_registrar.info'),
+    )) {
       final content = await buildStep.readAsString(input);
       final data = RegistrarIntermediate.fromJson(jsonDecode(content));
       final uri = data.uri;
@@ -30,8 +31,10 @@ class RegistrarBuilder implements Builder {
       adapters.addAll(data.adapters);
       if (data.registrarLocation) {
         if (registrarUri != null) {
-          final sortedUris =
-              [registrarUri, uri].map((e) => e.toString()).toList()..sort();
+          final sortedUris = [
+            registrarUri,
+            uri,
+          ].map((e) => e.toString()).toList()..sort();
           final urisString = sortedUris.map((e) => '- $e').join('\n');
           throw HiveError(
             'GenerateAdapters annotation found in more than one file:\n$urisString',
@@ -52,9 +55,9 @@ class RegistrarBuilder implements Builder {
     if (buildConfigFile.existsSync()) {
       final buildConfigContent = buildConfigFile.readAsStringSync();
       final buildConfig = loadYaml(buildConfigContent);
-      final configIgnores = buildConfig?['targets']?[r'$default']?['builders']
-                  ?['source_gen|combining_builder']?['options']
-              ?['ignore_for_file'] as YamlList? ??
+      final configIgnores =
+          buildConfig?['targets']?[r'$default']?['builders']?['source_gen|combining_builder']?['options']?['ignore_for_file']
+              as YamlList? ??
           [];
       ignores.addAll(configIgnores.cast<String>());
     }

--- a/hive_generator/lib/src/builder/registrar_intermediate_builder.dart
+++ b/hive_generator/lib/src/builder/registrar_intermediate_builder.dart
@@ -22,8 +22,9 @@ class RegistrarIntermediateBuilder implements Builder {
     final library = await buildStep.inputLibrary;
     final adapters = <String>[];
 
-    final hiveTypeElements = LibraryReader(library)
-        .annotatedWith(TypeChecker.typeNamed(HiveType, inPackage: 'hive_ce'));
+    final hiveTypeElements = LibraryReader(
+      library,
+    ).annotatedWith(TypeChecker.typeNamed(HiveType, inPackage: 'hive_ce'));
     for (final annotatedElement in hiveTypeElements) {
       final annotation = annotatedElement.annotation;
       final element = annotatedElement.element;
@@ -36,14 +37,17 @@ class RegistrarIntermediateBuilder implements Builder {
     // If the registrar should be placed next to this file
     final bool registrarLocation;
 
-    final generateAdaptersChecker =
-        TypeChecker.typeNamed(GenerateAdapters, inPackage: 'hive_ce');
+    final generateAdaptersChecker = TypeChecker.typeNamed(
+      GenerateAdapters,
+      inPackage: 'hive_ce',
+    );
     final libraryReader = LibraryReader(library);
 
-    final generateAdaptersElements =
-        libraryReader.annotatedWith(generateAdaptersChecker);
-    final generateAdaptersDirectives =
-        libraryReader.libraryDirectivesAnnotatedWith(generateAdaptersChecker);
+    final generateAdaptersElements = libraryReader.annotatedWith(
+      generateAdaptersChecker,
+    );
+    final generateAdaptersDirectives = libraryReader
+        .libraryDirectivesAnnotatedWith(generateAdaptersChecker);
 
     final generateAdaptersAnnotationReaders = [
       ...generateAdaptersElements.map((e) => e.annotation),
@@ -52,10 +56,12 @@ class RegistrarIntermediateBuilder implements Builder {
 
     // Read multiple annotations if they exist
     final generateAdaptersAnnotationObjects = [
-      ...generateAdaptersElements
-          .expand((e) => generateAdaptersChecker.annotationsOf(e.element)),
-      ...generateAdaptersDirectives
-          .expand((e) => generateAdaptersChecker.annotationsOf(e.directive)),
+      ...generateAdaptersElements.expand(
+        (e) => generateAdaptersChecker.annotationsOf(e.element),
+      ),
+      ...generateAdaptersDirectives.expand(
+        (e) => generateAdaptersChecker.annotationsOf(e.directive),
+      ),
     ];
 
     if (generateAdaptersAnnotationObjects.length > 1) {

--- a/hive_generator/lib/src/builder/schema_migrator_builder.dart
+++ b/hive_generator/lib/src/builder/schema_migrator_builder.dart
@@ -9,7 +9,6 @@ import 'dart:async';
 import 'package:hive_ce_generator/src/helper/helper.dart';
 import 'package:hive_ce_generator/src/model/hive_schema.dart';
 import 'package:source_gen/source_gen.dart';
-import 'package:source_helper/source_helper.dart';
 import 'package:meta/meta.dart';
 
 /// Generate a Hive schema from existing HiveType annotations
@@ -33,8 +32,7 @@ class SchemaMigratorBuilder implements Builder {
   static String hasNoPublicGetter({
     required String className,
     required String fieldName,
-  }) =>
-      '$className.$fieldName does not have a public getter';
+  }) => '$className.$fieldName does not have a public getter';
 
   @override
   final buildExtensions = const {
@@ -47,8 +45,9 @@ class SchemaMigratorBuilder implements Builder {
     await for (final input in buildStep.findAssets(Glob('**/*.dart'))) {
       if (!await buildStep.resolver.isLibrary(input)) continue;
       final library = await buildStep.resolver.libraryFor(input);
-      final hiveTypeElements = LibraryReader(library)
-          .annotatedWith(TypeChecker.typeNamed(HiveType, inPackage: 'hive_ce'));
+      final hiveTypeElements = LibraryReader(
+        library,
+      ).annotatedWith(TypeChecker.typeNamed(HiveType, inPackage: 'hive_ce'));
       hiveTypes.addAll(hiveTypeElements);
     }
 
@@ -85,8 +84,9 @@ class SchemaMigratorBuilder implements Builder {
       final accessors = [
         ...cls.getters,
         ...cls.setters,
-        ...cls.allSupertypes
-            .expand((it) => [...it.element.getters, ...it.element.setters]),
+        ...cls.allSupertypes.expand(
+          (it) => [...it.element.getters, ...it.element.setters],
+        ),
       ];
       final info = _SchemaInfo(
         uri: uri,
@@ -116,19 +116,20 @@ class SchemaMigratorBuilder implements Builder {
 
       final firstPassFields = info.schema.fields.keys.toSet();
       final secondPassFields = secondPassInfo.schema.fields.keys.toSet();
-      final accessorsWithoutAnnotations =
-          secondPassFields.difference(firstPassFields);
+      final accessorsWithoutAnnotations = secondPassFields.difference(
+        firstPassFields,
+      );
 
-      schemaInfos
-          .add(info.copyWith(ignoredFields: accessorsWithoutAnnotations));
+      schemaInfos.add(
+        info.copyWith(ignoredFields: accessorsWithoutAnnotations),
+      );
     }
     schemaInfos.sort((a, b) => a.schema.typeId.compareTo(b.schema.typeId));
-    final nextTypeId =
-        schemaInfos.isEmpty ? 0 : schemaInfos.last.schema.typeId + 1;
+    final nextTypeId = schemaInfos.isEmpty
+        ? 0
+        : schemaInfos.last.schema.typeId + 1;
 
-    final types = {
-      for (final type in schemaInfos) type.className: type.schema,
-    };
+    final types = {for (final type in schemaInfos) type.className: type.schema};
 
     final imports = schemaInfos
         .map((e) => e.uri)
@@ -171,14 +172,14 @@ class _SchemaInfo {
     required ConstructorElement constructor,
     required List<PropertyAccessorElement> accessors,
     required HiveSchemaType schema,
-  })  : ignoredFields = {},
-        schema = _sanitizeSchema(
-          className: className,
-          isEnum: isEnum,
-          schema: schema,
-          constructor: constructor,
-          accessors: accessors,
-        );
+  }) : ignoredFields = {},
+       schema = _sanitizeSchema(
+         className: className,
+         isEnum: isEnum,
+         schema: schema,
+         constructor: constructor,
+         accessors: accessors,
+       );
 
   const _SchemaInfo._({
     required this.uri,
@@ -187,15 +188,12 @@ class _SchemaInfo {
     required this.schema,
   });
 
-  _SchemaInfo copyWith({
-    Set<String>? ignoredFields,
-  }) =>
-      _SchemaInfo._(
-        uri: uri,
-        className: className,
-        ignoredFields: ignoredFields ?? this.ignoredFields,
-        schema: schema,
-      );
+  _SchemaInfo copyWith({Set<String>? ignoredFields}) => _SchemaInfo._(
+    uri: uri,
+    className: className,
+    ignoredFields: ignoredFields ?? this.ignoredFields,
+    schema: schema,
+  );
 
   static HiveSchemaType _sanitizeSchema({
     required String className,
@@ -210,13 +208,16 @@ class _SchemaInfo {
     final sanitizedFields = <String, HiveSchemaField>{};
     for (final MapEntry(key: fieldName, value: schema)
         in schema.fields.entries) {
-      final publicFieldName =
-          fieldName.startsWith('_') ? fieldName.substring(1) : fieldName;
+      final publicFieldName = fieldName.startsWith('_')
+          ? fieldName.substring(1)
+          : fieldName;
 
-      final isInConstructor = constructor.formalParameters
-          .any((e) => e.displayName == publicFieldName);
-      final publicAccessors =
-          accessors.where((e) => e.displayName == publicFieldName).toList();
+      final isInConstructor = constructor.formalParameters.any(
+        (e) => e.displayName == publicFieldName,
+      );
+      final publicAccessors = accessors
+          .where((e) => e.displayName == publicFieldName)
+          .toList();
       final hasPublicSetter = publicAccessors.any((e) => e is SetterElement);
       final hasPublicGetter = publicAccessors.any((e) => e is GetterElement);
 

--- a/hive_generator/lib/src/generator/adapters_generator.dart
+++ b/hive_generator/lib/src/generator/adapters_generator.dart
@@ -18,16 +18,14 @@ class AdaptersGenerator extends GeneratorForAnnotation<GenerateAdapters> {
     ElementDirective directive,
     ConstantReader annotation,
     BuildStep buildStep,
-  ) =>
-      _generate(annotation, buildStep);
+  ) => _generate(annotation, buildStep);
 
   @override
   Future<String> generateForAnnotatedElement(
     Element element,
     ConstantReader annotation,
     BuildStep buildStep,
-  ) =>
-      _generate(annotation, buildStep);
+  ) => _generate(annotation, buildStep);
 
   Future<String> _generate(
     ConstantReader annotation,
@@ -40,22 +38,26 @@ class AdaptersGenerator extends GeneratorForAnnotation<GenerateAdapters> {
     final HiveSchema schema;
     if (await buildStep.canRead(schemaAsset)) {
       final schemaContent = await buildStep.readAsString(schemaAsset);
-      schema =
-          HiveSchema.fromJson(jsonDecode(jsonEncode(loadYaml(schemaContent))));
+      schema = HiveSchema.fromJson(
+        jsonDecode(jsonEncode(loadYaml(schemaContent))),
+      );
     } else {
       schema = HiveSchema(nextTypeId: revived.firstTypeId, types: {});
     }
     _validateSchema(schema);
 
     // Sort existing types by type ID
-    final existingSpecs = revived.specs
-        .where((spec) => schema.types.containsKey(spec.type.getDisplayString()))
-        .toList()
-      ..sort((a, b) {
-        final aTypeId = schema.types[a.type.getDisplayString()]!.typeId;
-        final bTypeId = schema.types[b.type.getDisplayString()]!.typeId;
-        return aTypeId.compareTo(bTypeId);
-      });
+    final existingSpecs =
+        revived.specs
+            .where(
+              (spec) => schema.types.containsKey(spec.type.getDisplayString()),
+            )
+            .toList()
+          ..sort((a, b) {
+            final aTypeId = schema.types[a.type.getDisplayString()]!.typeId;
+            final bTypeId = schema.types[b.type.getDisplayString()]!.typeId;
+            return aTypeId.compareTo(bTypeId);
+          });
 
     // Maintain order of new types
     final newSpecs = revived.specs
@@ -77,12 +79,9 @@ class AdaptersGenerator extends GeneratorForAnnotation<GenerateAdapters> {
     for (final spec in existingSpecs + newSpecs) {
       final typeKey = spec.type.element!.displayName;
 
-      final schemaType = schema.types[typeKey] ??
-          HiveSchemaType(
-            typeId: generateTypeId(),
-            nextIndex: 0,
-            fields: {},
-          );
+      final schemaType =
+          schema.types[typeKey] ??
+          HiveSchemaType(typeId: generateTypeId(), nextIndex: 0, fields: {});
       final result = TypeAdapterGenerator.generateTypeAdapter(
         element: spec.type.element!,
         library: library,

--- a/hive_generator/lib/src/generator/type_adapter_generator.dart
+++ b/hive_generator/lib/src/generator/type_adapter_generator.dart
@@ -8,7 +8,6 @@ import 'package:hive_ce_generator/src/helper/helper.dart';
 import 'package:hive_ce_generator/src/helper/type_helper.dart';
 import 'package:hive_ce_generator/src/model/hive_schema.dart';
 import 'package:source_gen/source_gen.dart';
-import 'package:source_helper/source_helper.dart';
 import 'package:meta/meta.dart';
 
 /// TODO: Document this!
@@ -59,7 +58,8 @@ class TypeAdapterGenerator extends GeneratorForAnnotation<HiveType> {
         ? EnumAdapterBuilder(cls, getters)
         : ClassAdapterBuilder(cls, getters, setters);
 
-    final content = '''
+    final content =
+        '''
     class $adapterName extends TypeAdapter<${cls.displayName}> {
       @override
       final typeId = $typeId;
@@ -92,18 +92,20 @@ class TypeAdapterGenerator extends GeneratorForAnnotation<HiveType> {
   /// TODO: Document this!
   static Set<String> _getAllAccessorNames(InterfaceElement cls) {
     final isEnum = cls.thisType.isEnum;
-    final constructorFields = getConstructor(cls)
-        .formalParameters
-        .map((it) => it.displayName)
-        .toSet();
+    final constructorFields = getConstructor(
+      cls,
+    ).formalParameters.map((it) => it.displayName).toSet();
 
     final accessorNames = <String>{};
 
     final supertypes = cls.allSupertypes.map((it) => it.element);
     for (final type in [cls, ...supertypes]) {
       // Ignore Object base members
-      if (const TypeChecker.typeNamed(Object, inPackage: 'core', inSdk: true)
-          .isExactly(type)) {
+      if (const TypeChecker.typeNamed(
+        Object,
+        inPackage: 'core',
+        inSdk: true,
+      ).isExactly(type)) {
         continue;
       }
 
@@ -172,7 +174,8 @@ class TypeAdapterGenerator extends GeneratorForAnnotation<HiveType> {
       final int index;
       if (schema != null) {
         // Only generate one id per field name
-        index = schema.fields[name]?.index ??
+        index =
+            schema.fields[name]?.index ??
             newSchemaFields[name]?.index ??
             nextIndex++;
       } else if (annotation != null) {

--- a/hive_generator/lib/src/helper/helper.dart
+++ b/hive_generator/lib/src/helper/helper.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:analyzer/dart/constant/value.dart';
 import 'package:analyzer/dart/element/element.dart';
+import 'package:analyzer/dart/element/type.dart';
 import 'package:build/build.dart';
 import 'package:collection/collection.dart';
 import 'package:hive_ce/hive_ce.dart';
@@ -11,8 +12,19 @@ import 'package:path/path.dart' as path;
 import 'package:meta/meta.dart';
 import 'package:yaml_writer/yaml_writer.dart';
 
-final _hiveFieldChecker =
-    const TypeChecker.typeNamed(HiveField, inPackage: 'hive_ce');
+/// Convenience helpers for [DartType]
+extension DartTypeExtension on DartType {
+  /// Whether this type is an enum
+  bool get isEnum {
+    final type = this;
+    return type is InterfaceType && type.element is EnumElement;
+  }
+}
+
+final _hiveFieldChecker = const TypeChecker.typeNamed(
+  HiveField,
+  inPackage: 'hive_ce',
+);
 final _freezedDefaultChecker = const TypeChecker.fromUrl(
   'package:freezed_annotation/freezed_annotation.dart#Default',
 );
@@ -72,8 +84,10 @@ InterfaceElement getClass(Element element) {
 
 /// Generate a default adapter name from the type name
 String generateAdapterName(String typeName) {
-  var adapterName =
-      '${typeName}Adapter'.replaceAll(RegExp(r'[^A-Za-z0-9]+'), '');
+  var adapterName = '${typeName}Adapter'.replaceAll(
+    RegExp(r'[^A-Za-z0-9]+'),
+    '',
+  );
   if (adapterName.startsWith('_')) {
     adapterName = adapterName.substring(1);
   }

--- a/hive_generator/lib/src/helper/type_helper.dart
+++ b/hive_generator/lib/src/helper/type_helper.dart
@@ -1,7 +1,6 @@
 import 'package:analyzer/dart/constant/value.dart';
 import 'package:analyzer/dart/element/type.dart';
 import 'package:source_gen/source_gen.dart';
-import 'package:source_helper/source_helper.dart';
 
 /// TODO: Document this!
 const kConstConstructors = true;
@@ -67,7 +66,7 @@ String literalToString(DartObject object, List<String> typeInformation) {
   if (reader.isDouble || reader.isInt || reader.isString || reader.isBool) {
     final value = reader.literalValue;
 
-    if (value is String) return escapeDartString(value);
+    if (value is String) return _escapeDartString(value);
 
     if (value is double) {
       if (value.isNaN) {
@@ -136,3 +135,41 @@ String literalToString(DartObject object, List<String> typeInformation) {
 /// TODO: Document this!
 Never throwUnsupported(String message) =>
     throw InvalidGenerationSourceError('Error with `@HiveField`. $message');
+
+/// Returns a quoted String literal for [value] that can be used in generated
+/// Dart code.
+String _escapeDartString(String value) {
+  final escaped = StringBuffer("'");
+  for (final unit in value.runes) {
+    switch (unit) {
+      case 0x27: // '
+        escaped.write(r"\'");
+      case 0x5C: // \
+        escaped.write(r'\\');
+      case 0x24: // $
+        escaped.write(r'\$');
+      case 0x08: // \b
+        escaped.write(r'\b');
+      case 0x09: // \t
+        escaped.write(r'\t');
+      case 0x0A: // \n
+        escaped.write(r'\n');
+      case 0x0B: // \v
+        escaped.write(r'\v');
+      case 0x0C: // \f
+        escaped.write(r'\f');
+      case 0x0D: // \r
+        escaped.write(r'\r');
+      default:
+        if (unit < 0x20 || unit == 0x7F) {
+          escaped.write(
+            '\\x${unit.toRadixString(16).toUpperCase().padLeft(2, '0')}',
+          );
+        } else {
+          escaped.writeCharCode(unit);
+        }
+    }
+  }
+  escaped.write("'");
+  return escaped.toString();
+}

--- a/hive_generator/lib/src/model/registrar_intermediate.g.dart
+++ b/hive_generator/lib/src/model/registrar_intermediate.g.dart
@@ -9,18 +9,19 @@ part of 'registrar_intermediate.dart';
 // **************************************************************************
 
 RegistrarIntermediate _$RegistrarIntermediateFromJson(
-        Map<String, dynamic> json) =>
-    RegistrarIntermediate(
-      uri: Uri.parse(json['uri'] as String),
-      adapters:
-          (json['adapters'] as List<dynamic>).map((e) => e as String).toList(),
-      registrarLocation: json['registrarLocation'] as bool,
-    );
+  Map<String, dynamic> json,
+) => RegistrarIntermediate(
+  uri: Uri.parse(json['uri'] as String),
+  adapters: (json['adapters'] as List<dynamic>)
+      .map((e) => e as String)
+      .toList(),
+  registrarLocation: json['registrarLocation'] as bool,
+);
 
 Map<String, dynamic> _$RegistrarIntermediateToJson(
-        RegistrarIntermediate instance) =>
-    <String, dynamic>{
-      'uri': instance.uri.toString(),
-      'adapters': instance.adapters,
-      'registrarLocation': instance.registrarLocation,
-    };
+  RegistrarIntermediate instance,
+) => <String, dynamic>{
+  'uri': instance.uri.toString(),
+  'adapters': instance.adapters,
+  'registrarLocation': instance.registrarLocation,
+};

--- a/hive_generator/lib/src/model/revived_generate_adapter.dart
+++ b/hive_generator/lib/src/model/revived_generate_adapter.dart
@@ -17,18 +17,18 @@ class RevivedGenerateAdapters {
 
   /// Revive a GenerateAdapters annotation
   RevivedGenerateAdapters(ConstantReader annotation)
-      : specs = annotation
-            .read('specs')
-            .listValue
-            .map(RevivedAdapterSpec.fromObject)
-            .toList(),
-        firstTypeId = annotation.read('firstTypeId').intValue,
-        reservedTypeIds = annotation
-            .read('reservedTypeIds')
-            .setValue
-            .map((e) => e.toIntValue())
-            .whereType<int>()
-            .toSet();
+    : specs = annotation
+          .read('specs')
+          .listValue
+          .map(RevivedAdapterSpec.fromObject)
+          .toList(),
+      firstTypeId = annotation.read('firstTypeId').intValue,
+      reservedTypeIds = annotation
+          .read('reservedTypeIds')
+          .setValue
+          .map((e) => e.toIntValue())
+          .whereType<int>()
+          .toSet();
 }
 
 /// A revived adapter spec

--- a/hive_generator/pubspec.yaml
+++ b/hive_generator/pubspec.yaml
@@ -1,17 +1,16 @@
 name: hive_ce_generator
 description: Extension for Hive. Automatically generates TypeAdapters to store any class.
-version: 1.11.2
+version: 1.11.3
 homepage: https://github.com/IO-Design-Team/hive_ce/tree/main/hive_generator
 
 environment:
-  sdk: ^3.4.0
+  sdk: ^3.11.0
 
 dependencies:
   build: ^4.0.0
   source_gen: ^4.0.0
   hive_ce: ^2.16.0
-  analyzer: ^12.0.0
-  source_helper: ^1.1.0
+  analyzer: ^14.0.0
   glob: ^2.1.2
   path: ^1.9.0
   yaml: ^3.1.2
@@ -23,5 +22,4 @@ dependencies:
 dev_dependencies:
   test: ^1.17.11
   build_runner: ^2.5.4
-  rexios_lints: ^17.0.3
-  json_serializable: ^6.8.0
+  rexios_lints: ^18.1.0

--- a/hive_generator/test/adapters_generator_test.dart
+++ b/hive_generator/test/adapters_generator_test.dart
@@ -6,7 +6,8 @@ const directives = '''
 import 'package:hive_ce/hive_ce.dart';
 part 'hive_adapters.g.dart';''';
 
-const personSchema = '''
+const personSchema =
+    '''
 $schemaComment
 nextTypeId: 1
 types:
@@ -26,7 +27,8 @@ void main() {
       expectGeneration(
         input: {
           ...pubspec(),
-          'lib/hive/hive_adapters.dart': '''
+          'lib/hive/hive_adapters.dart':
+              '''
 $directives
 
 @GenerateAdapters([AdapterSpec<Person>()])
@@ -38,9 +40,7 @@ class Person {
 }
 ''',
         },
-        output: {
-          'lib/hive/hive_adapters.g.yaml': personSchema,
-        },
+        output: {'lib/hive/hive_adapters.g.yaml': personSchema},
       );
     });
 
@@ -50,7 +50,8 @@ class Person {
       expectGeneration(
         input: {
           ...pubspec(),
-          'lib/hive/hive_adapters.dart': '''
+          'lib/hive/hive_adapters.dart':
+              '''
 $directives
 
 @GenerateAdapters([AdapterSpec<Person2>(), AdapterSpec<Person>()])
@@ -71,7 +72,8 @@ class Person2 {
           'lib/hive/hive_adapters.g.yaml': personSchema,
         },
         output: {
-          'lib/hive/hive_adapters.g.yaml': '''
+          'lib/hive/hive_adapters.g.yaml':
+              '''
 $schemaComment
 nextTypeId: 2
 types:
@@ -102,7 +104,8 @@ types:
       expectGeneration(
         input: {
           ...pubspec(),
-          'lib/hive/hive_adapters.dart': '''
+          'lib/hive/hive_adapters.dart':
+              '''
 $directives
 
 @GenerateAdapters([AdapterSpec<Person2>()])
@@ -116,7 +119,8 @@ class Person2 {
           'lib/hive/hive_adapters.g.yaml': personSchema,
         },
         output: {
-          'lib/hive/hive_adapters.g.yaml': '''
+          'lib/hive/hive_adapters.g.yaml':
+              '''
 $schemaComment
 nextTypeId: 2
 types:
@@ -138,7 +142,8 @@ types:
       expectGeneration(
         input: {
           ...pubspec(),
-          'lib/hive/hive_adapters.dart': '''
+          'lib/hive/hive_adapters.dart':
+              '''
 $directives
 
 @GenerateAdapters([AdapterSpec<Person>()])
@@ -153,7 +158,8 @@ class Person {
           'lib/hive/hive_adapters.g.yaml': personSchema,
         },
         output: {
-          'lib/hive/hive_adapters.g.yaml': '''
+          'lib/hive/hive_adapters.g.yaml':
+              '''
 $schemaComment
 nextTypeId: 1
 types:
@@ -176,7 +182,8 @@ types:
       expectGeneration(
         input: {
           ...pubspec(),
-          'lib/hive/hive_adapters.dart': '''
+          'lib/hive/hive_adapters.dart':
+              '''
   $directives
   
   @GenerateAdapters([AdapterSpec<Person>(ignoredFields: {'balance', 'age'})])
@@ -191,7 +198,8 @@ types:
   ''',
         },
         output: {
-          'lib/hive/hive_adapters.g.yaml': '''
+          'lib/hive/hive_adapters.g.yaml':
+              '''
 $schemaComment
 nextTypeId: 1
 types:
@@ -212,7 +220,8 @@ types:
       expectGeneration(
         input: {
           ...pubspec(),
-          'lib/hive/hive_adapters.dart': '''
+          'lib/hive/hive_adapters.dart':
+              '''
 $directives
 
 @GenerateAdapters([AdapterSpec<Person>()])
@@ -226,7 +235,8 @@ class Person {
           'lib/hive/hive_adapters.g.yaml': personSchema,
         },
         output: {
-          'lib/hive/hive_adapters.g.yaml': '''
+          'lib/hive/hive_adapters.g.yaml':
+              '''
 $schemaComment
 nextTypeId: 1
 types:
@@ -248,7 +258,8 @@ types:
         expectGeneration(
           input: {
             ...pubspec(),
-            'lib/hive/hive_adapters.dart': '''
+            'lib/hive/hive_adapters.dart':
+                '''
 $directives
 
 @GenerateAdapters([])
@@ -271,7 +282,8 @@ types:
         expectGeneration(
           input: {
             ...pubspec(),
-            'lib/hive/hive_adapters.dart': '''
+            'lib/hive/hive_adapters.dart':
+                '''
 $directives
 
 @GenerateAdapters([])
@@ -296,7 +308,8 @@ types:
         expectGeneration(
           input: {
             ...pubspec(),
-            'lib/hive/hive_adapters.dart': '''
+            'lib/hive/hive_adapters.dart':
+                '''
 $directives
 
 @GenerateAdapters([])
@@ -323,7 +336,8 @@ types:
         expectGeneration(
           input: {
             ...pubspec(),
-            'lib/hive/hive_adapters.dart': '''
+            'lib/hive/hive_adapters.dart':
+                '''
 $directives
 
 @GenerateAdapters([])
@@ -351,7 +365,8 @@ types:
       expectGeneration(
         input: {
           ...pubspec(),
-          'lib/hive/hive_adapters.dart': '''
+          'lib/hive/hive_adapters.dart':
+              '''
 $directives
 
 @GenerateAdapters([AdapterSpec<Person>(), AdapterSpec<Person2>()], reservedTypeIds: {1})
@@ -371,7 +386,8 @@ class Person2 {
 ''',
         },
         output: {
-          'lib/hive/hive_adapters.g.yaml': '''
+          'lib/hive/hive_adapters.g.yaml':
+              '''
 $schemaComment
 nextTypeId: 3
 types:

--- a/hive_generator/test/registrar_builder_test.dart
+++ b/hive_generator/test/registrar_builder_test.dart
@@ -16,9 +16,7 @@ part 'type.g.dart';
 class Type {}
 ''',
         },
-        output: {
-          'lib/hive_registrar.g.dart': fileExists,
-        },
+        output: {'lib/hive_registrar.g.dart': fileExists},
       );
     });
 
@@ -34,9 +32,7 @@ part 'hive_adapters.g.dart';
 void _() {}
 ''',
         },
-        output: {
-          'lib/hive_registrar.g.dart': fileDoesNotExist,
-        },
+        output: {'lib/hive_registrar.g.dart': fileDoesNotExist},
       );
     });
 
@@ -52,9 +48,7 @@ part 'hive_adapters.g.dart';
 class Type {}
 ''',
         },
-        output: {
-          'lib/hive/hive_registrar.g.dart': fileExists,
-        },
+        output: {'lib/hive/hive_registrar.g.dart': fileExists},
       );
     });
 

--- a/hive_generator/test/schema_migrator_test.dart
+++ b/hive_generator/test/schema_migrator_test.dart
@@ -62,23 +62,14 @@ void main() {
   group('schema_migrator', () {
     test('does not run if not enabled', () {
       expectGeneration(
-        input: {
-          ...pubspec(),
-          ...adapters,
-        },
-        output: {
-          'lib/hive_schema.g.yaml': fileDoesNotExist,
-        },
+        input: {...pubspec(), ...adapters},
+        output: {'lib/hive_schema.g.yaml': fileDoesNotExist},
       );
     });
 
     test('generates schema', () {
       expectGeneration(
-        input: {
-          ...pubspec(),
-          ...buildYaml,
-          ...adapters,
-        },
+        input: {...pubspec(), ...buildYaml, ...adapters},
         output: {
           'lib/hive/hive_adapters.dart': '''
 import 'package:hive_ce/hive_ce.dart';
@@ -93,7 +84,8 @@ import 'package:hive_ce_generator_test/adapters_2.dart';
 ])
 part 'hive_adapters.g.dart';
 ''',
-          'lib/hive/hive_adapters.g.yaml': '''
+          'lib/hive/hive_adapters.g.yaml':
+              '''
 $schemaComment
 nextTypeId: 5
 types:
@@ -231,17 +223,15 @@ part 'hive_adapters.g.dart';
       );
     });
 
-    test(
-      'works with freezed classes',
-      () {
-        expectGeneration(
-          input: {
-            ...pubspec(
-              dependencies: {'freezed_annotation: any'},
-              devDependencies: {'freezed: any'},
-            ),
-            ...buildYaml,
-            'lib/adapters.dart': '''
+    test('works with freezed classes', () {
+      expectGeneration(
+        input: {
+          ...pubspec(
+            dependencies: {'freezed_annotation: any'},
+            devDependencies: {'freezed: any'},
+          ),
+          ...buildYaml,
+          'lib/adapters.dart': '''
 import 'package:hive_ce/hive_ce.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
@@ -254,9 +244,9 @@ sealed class Class with _\$Class {
   factory Class({@HiveField(0) required int value}) = _Class;
 }
 ''',
-          },
-          output: {
-            'lib/hive/hive_adapters.dart': '''
+        },
+        output: {
+          'lib/hive/hive_adapters.dart': '''
 import 'package:hive_ce/hive_ce.dart';
 import 'package:hive_ce_generator_test/adapters.dart';
 
@@ -265,7 +255,8 @@ import 'package:hive_ce_generator_test/adapters.dart';
 ])
 part 'hive_adapters.g.dart';
 ''',
-            'lib/hive/hive_adapters.g.yaml': '''
+          'lib/hive/hive_adapters.g.yaml':
+              '''
 $schemaComment
 nextTypeId: 1
 types:
@@ -276,10 +267,8 @@ types:
       value:
         index: 0
 ''',
-          },
-        );
-      },
-      skip: 'Waiting on freezed analyzer 9 suport',
-    );
+        },
+      );
+    }, skip: 'Waiting on freezed analyzer 9 suport');
   });
 }

--- a/hive_generator/test/test_utils.dart
+++ b/hive_generator/test/test_utils.dart
@@ -27,11 +27,12 @@ void expectGeneration({
 }) {
   final projectRoot = createTestProject(input);
   Process.runSync('dart', ['pub', 'get'], workingDirectory: projectRoot);
-  final result = Process.runSync(
-    'dart',
-    ['pub', 'run', 'build_runner', 'build'],
-    workingDirectory: projectRoot,
-  );
+  final result = Process.runSync('dart', [
+    'pub',
+    'run',
+    'build_runner',
+    'build',
+  ], workingDirectory: projectRoot);
 
   if (debug) print(result.stdout);
 
@@ -57,8 +58,9 @@ void expectGeneration({
 }
 
 String createTestProject(Map<String, String> project) {
-  final directory =
-      Directory.systemTemp.createTempSync('hive_ce_generator_test');
+  final directory = Directory.systemTemp.createTempSync(
+    'hive_ce_generator_test',
+  );
 
   for (final MapEntry(:key, :value) in project.entries) {
     File(path.join(directory.path, key))
@@ -76,7 +78,8 @@ Map<String, String> pubspec({
   final hiveGeneratorPath = path.absolute(path.current);
 
   return {
-    'pubspec.yaml': '''
+    'pubspec.yaml':
+        '''
 name: hive_ce_generator_test
 
 environment:

--- a/hive_generator/test/type_adapter_generator_test.dart
+++ b/hive_generator/test/type_adapter_generator_test.dart
@@ -5,10 +5,7 @@ void main() {
   group('generateName', () {
     test('.generateName()', () {
       expect(generateAdapterName(r'_$User'), 'UserAdapter');
-      expect(
-        generateAdapterName(r'_$_SomeClass'),
-        'SomeClassAdapter',
-      );
+      expect(generateAdapterName(r'_$_SomeClass'), 'SomeClassAdapter');
     });
   });
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Bump `hive_ce_generator` to `analyzer: ^14.0.0` and Dart SDK `^3.11.0`
- Remove the `source_helper` dependency (still capped below analyzer 14) and replace its small usage (`isEnum`, string escaping) with local helpers
- Update `rexios_lints` to `^18.1.0` and adjust example/benchmark packages that path-depend on the generator

## Test plan
- [x] `dart pub get` in `hive_generator`
- [x] `dart analyze --fatal-infos` in `hive_generator`
- [x] `dart test` in `hive_generator`
- [x] `pana --no-warning --exit-code-threshold 0` (160/160)
- [ ] CI green on this PR

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-290fb5ae-0af9-4771-9a36-1ab240aea021"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-290fb5ae-0af9-4771-9a36-1ab240aea021"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

