### PR TITLE
Enable the not_null_assertion lint and remove null assertions

### DIFF
--- a/hive/analysis_options.yaml
+++ b/hive/analysis_options.yaml
@@ -3,8 +3,3 @@ include: package:rexios_lints/dart/package_extra.yaml
 linter:
   rules:
     - require_trailing_commas
-
-plugins:
-  rexios_lints:
-    diagnostics:
-      not_null_assertion: false

--- a/hive/lib/src/backend/js/native/backend_manager.dart
+++ b/hive/lib/src/backend/js/native/backend_manager.dart
@@ -10,15 +10,7 @@ import 'package:web/web.dart';
 /// Opens IndexedDB databases
 class BackendManager implements BackendManagerInterface {
   /// TODO: Document this!
-  IDBFactory? get indexedDB => window.self.indexedDB;
-
-  IDBFactory get _indexedDB {
-    final indexedDB = this.indexedDB;
-    if (indexedDB == null) {
-      throw HiveError('IndexedDB is not available.');
-    }
-    return indexedDB;
-  }
+  IDBFactory get indexedDB => window.self.indexedDB;
 
   @override
   Future<StorageBackend> open(
@@ -33,7 +25,7 @@ class BackendManager implements BackendManagerInterface {
     final databaseName = collection ?? name;
     final objectStoreName = collection == null ? 'box' : name;
 
-    final request = _indexedDB.open(databaseName, 1);
+    final request = indexedDB.open(databaseName, 1);
     request.onupgradeneeded = (IDBVersionChangeEvent e) {
       final db = (e.target as IDBOpenDBRequest).result as IDBDatabase;
       if (!db.objectStoreNames.contains(objectStoreName)) {
@@ -48,7 +40,7 @@ class BackendManager implements BackendManagerInterface {
       Logger.i(
         'Creating objectStore $objectStoreName in database $databaseName...',
       );
-      final request = _indexedDB.open(databaseName, db.version + 1);
+      final request = indexedDB.open(databaseName, db.version + 1);
       request.onupgradeneeded = (IDBVersionChangeEvent e) {
         final db = (e.target as IDBOpenDBRequest).result as IDBDatabase;
         if (!db.objectStoreNames.contains(objectStoreName)) {
@@ -73,9 +65,9 @@ class BackendManager implements BackendManagerInterface {
 
     // directly deleting the entire DB if a non-collection Box
     if (collection == null) {
-      await _indexedDB.deleteDatabase(databaseName).asFuture();
+      await indexedDB.deleteDatabase(databaseName).asFuture();
     } else {
-      final request = _indexedDB.open(databaseName, 1);
+      final request = indexedDB.open(databaseName, 1);
       request.onupgradeneeded = (IDBVersionChangeEvent e) {
         final db = (e.target as IDBOpenDBRequest).result as IDBDatabase;
         if (db.objectStoreNames.contains(objectStoreName)) {
@@ -84,7 +76,7 @@ class BackendManager implements BackendManagerInterface {
       }.toJS;
       final db = await request.asFuture<IDBDatabase>();
       if (db.objectStoreNames.length == 0) {
-        await _indexedDB.deleteDatabase(databaseName).asFuture();
+        await indexedDB.deleteDatabase(databaseName).asFuture();
       }
     }
   }
@@ -98,7 +90,7 @@ class BackendManager implements BackendManagerInterface {
     try {
       var exists = true;
       if (collection == null) {
-        final request = _indexedDB.open(databaseName, 1);
+        final request = indexedDB.open(databaseName, 1);
         request.onupgradeneeded = (IDBVersionChangeEvent e) {
           final transaction = (e.target as IDBOpenDBRequest).transaction;
           if (transaction == null) {
@@ -109,7 +101,7 @@ class BackendManager implements BackendManagerInterface {
         }.toJS;
         await request.asFuture();
       } else {
-        final request = _indexedDB.open(collection, 1);
+        final request = indexedDB.open(collection, 1);
         request.onupgradeneeded = (IDBVersionChangeEvent e) {
           final db = (e.target as IDBOpenDBRequest).result as IDBDatabase;
           exists = db.objectStoreNames.contains(objectStoreName);

--- a/hive/lib/src/backend/js/native/backend_manager.dart
+++ b/hive/lib/src/backend/js/native/backend_manager.dart
@@ -12,6 +12,14 @@ class BackendManager implements BackendManagerInterface {
   /// TODO: Document this!
   IDBFactory? get indexedDB => window.self.indexedDB;
 
+  IDBFactory get _indexedDB {
+    final db = indexedDB;
+    if (db == null) {
+      throw HiveError('IndexedDB is not available.');
+    }
+    return db;
+  }
+
   @override
   Future<StorageBackend> open(
     String name,
@@ -25,7 +33,7 @@ class BackendManager implements BackendManagerInterface {
     final databaseName = collection ?? name;
     final objectStoreName = collection == null ? 'box' : name;
 
-    final request = indexedDB!.open(databaseName, 1);
+    final request = _indexedDB.open(databaseName, 1);
     request.onupgradeneeded = (IDBVersionChangeEvent e) {
       final db = (e.target as IDBOpenDBRequest).result as IDBDatabase;
       if (!db.objectStoreNames.contains(objectStoreName)) {
@@ -40,7 +48,7 @@ class BackendManager implements BackendManagerInterface {
       Logger.i(
         'Creating objectStore $objectStoreName in database $databaseName...',
       );
-      final request = indexedDB!.open(databaseName, db.version + 1);
+      final request = _indexedDB.open(databaseName, db.version + 1);
       request.onupgradeneeded = (IDBVersionChangeEvent e) {
         final db = (e.target as IDBOpenDBRequest).result as IDBDatabase;
         if (!db.objectStoreNames.contains(objectStoreName)) {
@@ -65,9 +73,9 @@ class BackendManager implements BackendManagerInterface {
 
     // directly deleting the entire DB if a non-collection Box
     if (collection == null) {
-      await indexedDB!.deleteDatabase(databaseName).asFuture();
+      await _indexedDB.deleteDatabase(databaseName).asFuture();
     } else {
-      final request = indexedDB!.open(databaseName, 1);
+      final request = _indexedDB.open(databaseName, 1);
       request.onupgradeneeded = (IDBVersionChangeEvent e) {
         final db = (e.target as IDBOpenDBRequest).result as IDBDatabase;
         if (db.objectStoreNames.contains(objectStoreName)) {
@@ -76,7 +84,7 @@ class BackendManager implements BackendManagerInterface {
       }.toJS;
       final db = await request.asFuture<IDBDatabase>();
       if (db.objectStoreNames.length == 0) {
-        await indexedDB!.deleteDatabase(databaseName).asFuture();
+        await _indexedDB.deleteDatabase(databaseName).asFuture();
       }
     }
   }
@@ -90,14 +98,18 @@ class BackendManager implements BackendManagerInterface {
     try {
       var exists = true;
       if (collection == null) {
-        final request = indexedDB!.open(databaseName, 1);
+        final request = _indexedDB.open(databaseName, 1);
         request.onupgradeneeded = (IDBVersionChangeEvent e) {
-          (e.target as IDBOpenDBRequest).transaction!.abort();
+          final transaction = (e.target as IDBOpenDBRequest).transaction;
+          if (transaction == null) {
+            throw StateError('IDBOpenDBRequest has no transaction.');
+          }
+          transaction.abort();
           exists = false;
         }.toJS;
         await request.asFuture();
       } else {
-        final request = indexedDB!.open(collection, 1);
+        final request = _indexedDB.open(collection, 1);
         request.onupgradeneeded = (IDBVersionChangeEvent e) {
           final db = (e.target as IDBOpenDBRequest).result as IDBDatabase;
           exists = db.objectStoreNames.contains(objectStoreName);

--- a/hive/lib/src/backend/js/native/backend_manager.dart
+++ b/hive/lib/src/backend/js/native/backend_manager.dart
@@ -13,11 +13,11 @@ class BackendManager implements BackendManagerInterface {
   IDBFactory? get indexedDB => window.self.indexedDB;
 
   IDBFactory get _indexedDB {
-    final db = indexedDB;
-    if (db == null) {
+    final indexedDB = this.indexedDB;
+    if (indexedDB == null) {
       throw HiveError('IndexedDB is not available.');
     }
-    return db;
+    return indexedDB;
   }
 
   @override

--- a/hive/lib/src/backend/js/native/utils.dart
+++ b/hive/lib/src/backend/js/native/utils.dart
@@ -12,13 +12,9 @@ extension IDBRequestExtension on IDBRequest {
       completer.complete(result as T);
     }.toJS;
     onerror = (Event e) {
-      final error = this.error;
-      if (error == null) {
-        completer
-            .completeError(StateError('IDBRequest failed without an error'));
-      } else {
-        completer.completeError(error);
-      }
+      completer.completeError(
+        error ?? StateError('IDBRequest failed without an error'),
+      );
     }.toJS;
     return completer.future;
   }
@@ -40,12 +36,9 @@ extension IDBObjectStoreExtension on IDBObjectStore {
       cursor.continue_();
     }.toJS;
     request.onerror = (Event e) {
-      final error = request.error;
-      if (error == null) {
-        controller.addError(StateError('IDBRequest failed without an error'));
-      } else {
-        controller.addError(error);
-      }
+      controller.addError(
+        request.error ?? StateError('IDBRequest failed without an error'),
+      );
     }.toJS;
     return controller.stream;
   }

--- a/hive/lib/src/backend/js/native/utils.dart
+++ b/hive/lib/src/backend/js/native/utils.dart
@@ -12,11 +12,12 @@ extension IDBRequestExtension on IDBRequest {
       completer.complete(result as T);
     }.toJS;
     onerror = (Event e) {
-      final err = error;
-      if (err == null) {
-        completer.completeError(StateError('IDBRequest failed without an error'));
+      final error = this.error;
+      if (error == null) {
+        completer
+            .completeError(StateError('IDBRequest failed without an error'));
       } else {
-        completer.completeError(err);
+        completer.completeError(error);
       }
     }.toJS;
     return completer.future;
@@ -39,11 +40,11 @@ extension IDBObjectStoreExtension on IDBObjectStore {
       cursor.continue_();
     }.toJS;
     request.onerror = (Event e) {
-      final err = request.error;
-      if (err == null) {
+      final error = request.error;
+      if (error == null) {
         controller.addError(StateError('IDBRequest failed without an error'));
       } else {
-        controller.addError(err);
+        controller.addError(error);
       }
     }.toJS;
     return controller.stream;

--- a/hive/lib/src/backend/js/native/utils.dart
+++ b/hive/lib/src/backend/js/native/utils.dart
@@ -12,7 +12,12 @@ extension IDBRequestExtension on IDBRequest {
       completer.complete(result as T);
     }.toJS;
     onerror = (Event e) {
-      completer.completeError(error!);
+      final err = error;
+      if (err == null) {
+        completer.completeError(StateError('IDBRequest failed without an error'));
+      } else {
+        completer.completeError(err);
+      }
     }.toJS;
     return completer.future;
   }
@@ -34,7 +39,12 @@ extension IDBObjectStoreExtension on IDBObjectStore {
       cursor.continue_();
     }.toJS;
     request.onerror = (Event e) {
-      controller.addError(request.error!);
+      final err = request.error;
+      if (err == null) {
+        controller.addError(StateError('IDBRequest failed without an error'));
+      } else {
+        controller.addError(err);
+      }
     }.toJS;
     return controller.stream;
   }

--- a/hive/lib/src/backend/storage_backend_memory.dart
+++ b/hive/lib/src/backend/storage_backend_memory.dart
@@ -16,7 +16,7 @@ class StorageBackendMemory extends StorageBackend {
   Uint8List? _bytes;
 
   /// Not part of public API
-  StorageBackendMemory(Uint8List? bytes, this._cipher, this._keyCrc)
+  StorageBackendMemory(Uint8List bytes, this._cipher, this._keyCrc)
       : _bytes = bytes,
         _frameHelper = FrameHelper();
 

--- a/hive/lib/src/backend/storage_backend_memory.dart
+++ b/hive/lib/src/backend/storage_backend_memory.dart
@@ -33,8 +33,12 @@ class StorageBackendMemory extends StorageBackend {
     bool lazy, {
     bool isolated = false,
   }) {
+    final bytes = _bytes;
+    if (bytes == null) {
+      throw HiveError('Memory backend has already been initialized.');
+    }
     final recoveryOffset = _frameHelper.framesFromBytes(
-      _bytes!, // Initialized at constructor and nulled after initialization
+      bytes,
       keystore,
       registry,
       _cipher,

--- a/hive/lib/src/backend/storage_backend_memory.dart
+++ b/hive/lib/src/backend/storage_backend_memory.dart
@@ -29,7 +29,7 @@ class StorageBackendMemory extends StorageBackend {
   @override
   Future<void> initialize(
     TypeRegistry registry,
-    Keystore? keystore,
+    Keystore keystore,
     bool lazy, {
     bool isolated = false,
   }) {

--- a/hive/lib/src/backend/vm/backend_manager.dart
+++ b/hive/lib/src/backend/vm/backend_manager.dart
@@ -72,19 +72,15 @@ class BackendManager implements BackendManagerInterface {
     }
   }
 
+  String _boxDirectory(String? path, String? collection) {
+    if (path == null) throw ArgumentError.notNull('path');
+    if (path.endsWith(_delimiter)) path = path.substring(0, path.length - 1);
+    return collection == null ? path : path + collection;
+  }
+
   @override
   Future<void> deleteBox(String name, String? path, String? collection) async {
-    if (path == null) {
-      throw ArgumentError.notNull('path');
-    }
-
-    if (path.endsWith(_delimiter)) {
-      path = path.substring(0, path.length - 1);
-    }
-
-    if (collection != null) {
-      path = path + collection;
-    }
+    path = _boxDirectory(path, collection);
 
     await _deleteFileIfExists(File('$path$_delimiter$name.hive'));
     await _deleteFileIfExists(File('$path$_delimiter$name.hivec'));
@@ -99,17 +95,7 @@ class BackendManager implements BackendManagerInterface {
 
   @override
   Future<bool> boxExists(String name, String? path, String? collection) async {
-    if (path == null) {
-      throw ArgumentError.notNull('path');
-    }
-
-    if (path.endsWith(_delimiter)) {
-      path = path.substring(0, path.length - 1);
-    }
-
-    if (collection != null) {
-      path = path + collection;
-    }
+    path = _boxDirectory(path, collection);
 
     return await File('$path$_delimiter$name.hive').exists() ||
         await File('$path$_delimiter$name.hivec').exists() ||

--- a/hive/lib/src/backend/vm/backend_manager.dart
+++ b/hive/lib/src/backend/vm/backend_manager.dart
@@ -74,22 +74,21 @@ class BackendManager implements BackendManagerInterface {
 
   @override
   Future<void> deleteBox(String name, String? path, String? collection) async {
-    var resolvedPath = path;
-    if (resolvedPath == null) {
+    if (path == null) {
       throw ArgumentError.notNull('path');
     }
 
-    if (resolvedPath.endsWith(_delimiter)) {
-      resolvedPath = resolvedPath.substring(0, resolvedPath.length - 1);
+    if (path.endsWith(_delimiter)) {
+      path = path.substring(0, path.length - 1);
     }
 
     if (collection != null) {
-      resolvedPath = resolvedPath + collection;
+      path = path + collection;
     }
 
-    await _deleteFileIfExists(File('$resolvedPath$_delimiter$name.hive'));
-    await _deleteFileIfExists(File('$resolvedPath$_delimiter$name.hivec'));
-    await _deleteFileIfExists(File('$resolvedPath$_delimiter$name.lock'));
+    await _deleteFileIfExists(File('$path$_delimiter$name.hive'));
+    await _deleteFileIfExists(File('$path$_delimiter$name.hivec'));
+    await _deleteFileIfExists(File('$path$_delimiter$name.lock'));
   }
 
   Future<void> _deleteFileIfExists(File file) async {
@@ -100,21 +99,20 @@ class BackendManager implements BackendManagerInterface {
 
   @override
   Future<bool> boxExists(String name, String? path, String? collection) async {
-    var resolvedPath = path;
-    if (resolvedPath == null) {
+    if (path == null) {
       throw ArgumentError.notNull('path');
     }
 
-    if (resolvedPath.endsWith(_delimiter)) {
-      resolvedPath = resolvedPath.substring(0, resolvedPath.length - 1);
+    if (path.endsWith(_delimiter)) {
+      path = path.substring(0, path.length - 1);
     }
 
     if (collection != null) {
-      resolvedPath = resolvedPath + collection;
+      path = path + collection;
     }
 
-    return await File('$resolvedPath$_delimiter$name.hive').exists() ||
-        await File('$resolvedPath$_delimiter$name.hivec').exists() ||
-        await File('$resolvedPath$_delimiter$name.lock').exists();
+    return await File('$path$_delimiter$name.hive').exists() ||
+        await File('$path$_delimiter$name.hivec').exists() ||
+        await File('$path$_delimiter$name.lock').exists();
   }
 }

--- a/hive/lib/src/backend/vm/backend_manager.dart
+++ b/hive/lib/src/backend/vm/backend_manager.dart
@@ -74,17 +74,22 @@ class BackendManager implements BackendManagerInterface {
 
   @override
   Future<void> deleteBox(String name, String? path, String? collection) async {
-    ArgumentError.checkNotNull(path, 'path');
-
-    if (path!.endsWith(_delimiter)) path = path.substring(0, path.length - 1);
-
-    if (collection != null) {
-      path = path + collection;
+    var resolvedPath = path;
+    if (resolvedPath == null) {
+      throw ArgumentError.notNull('path');
     }
 
-    await _deleteFileIfExists(File('$path$_delimiter$name.hive'));
-    await _deleteFileIfExists(File('$path$_delimiter$name.hivec'));
-    await _deleteFileIfExists(File('$path$_delimiter$name.lock'));
+    if (resolvedPath.endsWith(_delimiter)) {
+      resolvedPath = resolvedPath.substring(0, resolvedPath.length - 1);
+    }
+
+    if (collection != null) {
+      resolvedPath = resolvedPath + collection;
+    }
+
+    await _deleteFileIfExists(File('$resolvedPath$_delimiter$name.hive'));
+    await _deleteFileIfExists(File('$resolvedPath$_delimiter$name.hivec'));
+    await _deleteFileIfExists(File('$resolvedPath$_delimiter$name.lock'));
   }
 
   Future<void> _deleteFileIfExists(File file) async {
@@ -95,16 +100,21 @@ class BackendManager implements BackendManagerInterface {
 
   @override
   Future<bool> boxExists(String name, String? path, String? collection) async {
-    ArgumentError.checkNotNull(path, 'path');
-
-    if (path!.endsWith(_delimiter)) path = path.substring(0, path.length - 1);
-
-    if (collection != null) {
-      path = path + collection;
+    var resolvedPath = path;
+    if (resolvedPath == null) {
+      throw ArgumentError.notNull('path');
     }
 
-    return await File('$path$_delimiter$name.hive').exists() ||
-        await File('$path$_delimiter$name.hivec').exists() ||
-        await File('$path$_delimiter$name.lock').exists();
+    if (resolvedPath.endsWith(_delimiter)) {
+      resolvedPath = resolvedPath.substring(0, resolvedPath.length - 1);
+    }
+
+    if (collection != null) {
+      resolvedPath = resolvedPath + collection;
+    }
+
+    return await File('$resolvedPath$_delimiter$name.hive').exists() ||
+        await File('$resolvedPath$_delimiter$name.hivec').exists() ||
+        await File('$resolvedPath$_delimiter$name.lock').exists();
   }
 }

--- a/hive/lib/src/backend/vm/storage_backend_vm.dart
+++ b/hive/lib/src/backend/vm/storage_backend_vm.dart
@@ -17,7 +17,8 @@ import 'package:hive_ce/src/util/logger.dart';
 import 'package:meta/meta.dart';
 
 extension on Frame {
-  /// The frame length, which is only set once the frame has been written
+  /// The frame length, which is only set once the frame has been read from or
+  /// written to disk
   int get requireLength => length ?? (throw HiveError('Frame has no length.'));
 }
 

--- a/hive/lib/src/backend/vm/storage_backend_vm.dart
+++ b/hive/lib/src/backend/vm/storage_backend_vm.dart
@@ -145,7 +145,11 @@ class StorageBackendVm extends StorageBackend {
     return _sync.syncRead(() async {
       await readRaf.setPosition(frame.offset);
 
-      final bytes = await readRaf.read(frame.length!);
+      final length = frame.length;
+      if (length == null) {
+        throw HiveError('Frame has no length.');
+      }
+      final bytes = await readRaf.read(length);
 
       final reader = BinaryReaderImpl(bytes, registry);
       final readFrame = reader.readFrame(
@@ -188,7 +192,11 @@ class StorageBackendVm extends StorageBackend {
 
       for (final frame in frames) {
         frame.offset = writeOffset;
-        writeOffset += frame.length!;
+        final length = frame.length;
+        if (length == null) {
+          throw HiveError('Frame has no length.');
+        }
+        writeOffset += length;
       }
     });
   }
@@ -222,12 +230,16 @@ class StorageBackendVm extends StorageBackend {
             reader.skip(skip);
           }
 
-          if (reader.remainingInBuffer < frame.length!) {
-            if (await reader.loadBytes(frame.length!) < frame.length!) {
+          final length = frame.length;
+          if (length == null) {
+            throw HiveError('Frame has no length.');
+          }
+          if (reader.remainingInBuffer < length) {
+            if (await reader.loadBytes(length) < length) {
               throw HiveError('Could not compact box: Unexpected EOF.');
             }
           }
-          await writer.write(reader.viewBytes(frame.length!));
+          await writer.write(reader.viewBytes(length));
         }
         await writer.flush();
       } finally {
@@ -252,7 +264,11 @@ class StorageBackendVm extends StorageBackend {
       for (final frame in sortedFrames) {
         if (frame.offset == -1) continue;
         frame.offset = offset;
-        offset += frame.length!;
+        final length = frame.length;
+        if (length == null) {
+          throw HiveError('Frame has no length.');
+        }
+        offset += length;
       }
     });
   }

--- a/hive/lib/src/backend/vm/storage_backend_vm.dart
+++ b/hive/lib/src/backend/vm/storage_backend_vm.dart
@@ -16,6 +16,11 @@ import 'package:hive_ce/src/io/frame_io_helper.dart';
 import 'package:hive_ce/src/util/logger.dart';
 import 'package:meta/meta.dart';
 
+extension on Frame {
+  /// The frame length, which is only set once the frame has been written
+  int get requireLength => length ?? (throw HiveError('Frame has no length.'));
+}
+
 /// Storage backend for the Dart VM
 class StorageBackendVm extends StorageBackend {
   final File _file;
@@ -145,11 +150,7 @@ class StorageBackendVm extends StorageBackend {
     return _sync.syncRead(() async {
       await readRaf.setPosition(frame.offset);
 
-      final length = frame.length;
-      if (length == null) {
-        throw HiveError('Frame has no length.');
-      }
-      final bytes = await readRaf.read(length);
+      final bytes = await readRaf.read(frame.requireLength);
 
       final reader = BinaryReaderImpl(bytes, registry);
       final readFrame = reader.readFrame(
@@ -192,11 +193,7 @@ class StorageBackendVm extends StorageBackend {
 
       for (final frame in frames) {
         frame.offset = writeOffset;
-        final length = frame.length;
-        if (length == null) {
-          throw HiveError('Frame has no length.');
-        }
-        writeOffset += length;
+        writeOffset += frame.requireLength;
       }
     });
   }
@@ -230,10 +227,7 @@ class StorageBackendVm extends StorageBackend {
             reader.skip(skip);
           }
 
-          final length = frame.length;
-          if (length == null) {
-            throw HiveError('Frame has no length.');
-          }
+          final length = frame.requireLength;
           if (reader.remainingInBuffer < length) {
             if (await reader.loadBytes(length) < length) {
               throw HiveError('Could not compact box: Unexpected EOF.');
@@ -264,11 +258,7 @@ class StorageBackendVm extends StorageBackend {
       for (final frame in sortedFrames) {
         if (frame.offset == -1) continue;
         frame.offset = offset;
-        final length = frame.length;
-        if (length == null) {
-          throw HiveError('Frame has no length.');
-        }
-        offset += length;
+        offset += frame.requireLength;
       }
     });
   }

--- a/hive/lib/src/binary/binary_writer_impl.dart
+++ b/hive/lib/src/binary/binary_writer_impl.dart
@@ -28,8 +28,7 @@ class BinaryWriterImpl extends BinaryWriter {
   @pragma('vm:prefer-inline')
   @pragma('dart2js:tryInline')
   ByteData get _byteData {
-    _byteDataInstance ??= ByteData.view(_buffer.buffer);
-    return _byteDataInstance!;
+    return _byteDataInstance ??= ByteData.view(_buffer.buffer);
   }
 
   /// Not part of public API

--- a/hive/lib/src/binary/binary_writer_impl.dart
+++ b/hive/lib/src/binary/binary_writer_impl.dart
@@ -27,9 +27,7 @@ class BinaryWriterImpl extends BinaryWriter {
 
   @pragma('vm:prefer-inline')
   @pragma('dart2js:tryInline')
-  ByteData get _byteData {
-    return _byteDataInstance ??= ByteData.view(_buffer.buffer);
-  }
+  ByteData get _byteData => _byteDataInstance ??= ByteData.view(_buffer.buffer);
 
   /// Not part of public API
   BinaryWriterImpl(TypeRegistry typeRegistry)

--- a/hive/lib/src/binary/frame_helper.dart
+++ b/hive/lib/src/binary/frame_helper.dart
@@ -29,11 +29,10 @@ class FrameHelper {
       );
       if (frame == null) return frameOffset;
 
-      final store = keystore;
-      if (store == null) {
+      if (keystore == null) {
         throw HiveError('Keystore is required to read frames.');
       }
-      store.insert(frame, notify: false);
+      keystore.insert(frame, notify: false);
     }
 
     return -1;

--- a/hive/lib/src/binary/frame_helper.dart
+++ b/hive/lib/src/binary/frame_helper.dart
@@ -29,7 +29,11 @@ class FrameHelper {
       );
       if (frame == null) return frameOffset;
 
-      keystore!.insert(frame, notify: false);
+      final store = keystore;
+      if (store == null) {
+        throw HiveError('Keystore is required to read frames.');
+      }
+      store.insert(frame, notify: false);
     }
 
     return -1;

--- a/hive/lib/src/binary/frame_helper.dart
+++ b/hive/lib/src/binary/frame_helper.dart
@@ -9,7 +9,7 @@ class FrameHelper {
   /// Not part of public API
   int framesFromBytes(
     Uint8List bytes,
-    Keystore? keystore,
+    Keystore keystore,
     TypeRegistry registry,
     HiveCipher? cipher,
     int? keyCrc, {
@@ -29,9 +29,6 @@ class FrameHelper {
       );
       if (frame == null) return frameOffset;
 
-      if (keystore == null) {
-        throw HiveError('Keystore is required to read frames.');
-      }
       keystore.insert(frame, notify: false);
     }
 

--- a/hive/lib/src/box/box_base_impl.dart
+++ b/hive/lib/src/box/box_base_impl.dart
@@ -94,7 +94,7 @@ abstract class BoxBaseImpl<E> implements BoxBase<E>, InspectableBox {
   @override
   dynamic keyAt(int index) {
     checkOpen();
-    return keystore.getAt(index)!.key;
+    return keystore.keyAt(index);
   }
 
   /// Not part of public API
@@ -138,12 +138,12 @@ abstract class BoxBaseImpl<E> implements BoxBase<E>, InspectableBox {
 
   @override
   Future<void> putAt(int index, E value) {
-    return putAll({keystore.getAt(index)!.key: value});
+    return putAll({keystore.keyAt(index): value});
   }
 
   @override
   Future<void> deleteAt(int index) {
-    return delete(keystore.getAt(index)!.key);
+    return delete(keystore.keyAt(index));
   }
 
   @override

--- a/hive/lib/src/box/keystore.dart
+++ b/hive/lib/src/box/keystore.dart
@@ -212,21 +212,22 @@ class Keystore<E> {
     final canceled = transactions.removeFirst();
 
     deleted_loop:
-    for (final key in canceled.deleted.keys) {
-      final deletedFrame = canceled.deleted[key];
+    for (final entry in canceled.deleted.entries) {
+      final key = entry.key;
+      final deletedFrame = entry.value;
       for (final t in transactions) {
         if (t.deleted.containsKey(key)) {
-          t.deleted[key] = deletedFrame!;
+          t.deleted[key] = deletedFrame;
           continue deleted_loop;
         }
         if (t.added.contains(key)) {
-          t.deleted[key] = deletedFrame!;
+          t.deleted[key] = deletedFrame;
           continue deleted_loop;
         }
       }
 
       _store.insert(key, deletedFrame);
-      _notifier.notify(deletedFrame!);
+      _notifier.notify(deletedFrame);
     }
 
     added_loop:

--- a/hive/lib/src/box_collection/box_collection.dart
+++ b/hive/lib/src/box_collection/box_collection.dart
@@ -81,16 +81,13 @@ class BoxCollection implements implementation.BoxCollection {
     bool readOnly = false,
   }) async {
     await runZoned(() async {
+      final boxNames =
+          CollectionBox.transactionBoxes[Zone.current] = <String>{};
       try {
-        CollectionBox.transactionBoxes[Zone.current] = <String>{};
         await action();
       } finally {
         final flushFutures = <Future<void>>[];
-        final transactionBoxes = CollectionBox.transactionBoxes[Zone.current];
-        if (transactionBoxes == null) {
-          throw StateError('Transaction zone has no box set.');
-        }
-        for (final boxName in transactionBoxes) {
+        for (final boxName in boxNames) {
           final i = _openBoxes.indexWhere((box) => box.name == boxName);
           if (i != -1) {
             flushFutures.add(_openBoxes[i].flush());
@@ -240,27 +237,20 @@ class CollectionBox<V> implements implementation.CollectionBox<V> {
   }
 
   Future<void> _flushOrMark() async {
-    final zone = _getTransactionZone();
-    if (zone == null) {
+    final boxNames = _getTransactionBoxes();
+    if (boxNames == null) {
       await flush();
     } else {
-      final transactionBoxes = CollectionBox.transactionBoxes[zone];
-      if (transactionBoxes == null) {
-        throw StateError('Transaction zone has no box set.');
-      }
-      transactionBoxes.add(name);
+      boxNames.add(name);
     }
   }
 
-  Zone? _getTransactionZone([Zone? testZone]) {
+  Set<String>? _getTransactionBoxes([Zone? testZone]) {
     testZone ??= Zone.current;
     if (testZone == Zone.root) {
       return null;
     }
-    if (transactionBoxes.keys.contains(testZone)) {
-      return testZone;
-    }
-    return _getTransactionZone(testZone.parent);
+    return transactionBoxes[testZone] ?? _getTransactionBoxes(testZone.parent);
   }
 
   static const _maxKeyLength = 255;

--- a/hive/lib/src/box_collection/box_collection.dart
+++ b/hive/lib/src/box_collection/box_collection.dart
@@ -86,7 +86,11 @@ class BoxCollection implements implementation.BoxCollection {
         await action();
       } finally {
         final flushFutures = <Future<void>>[];
-        for (final boxName in CollectionBox.transactionBoxes[Zone.current]!) {
+        final transactionBoxes = CollectionBox.transactionBoxes[Zone.current];
+        if (transactionBoxes == null) {
+          throw StateError('Transaction zone has no box set.');
+        }
+        for (final boxName in transactionBoxes) {
           final i = _openBoxes.indexWhere((box) => box.name == boxName);
           if (i != -1) {
             flushFutures.add(_openBoxes[i].flush());
@@ -240,7 +244,11 @@ class CollectionBox<V> implements implementation.CollectionBox<V> {
     if (zone == null) {
       await flush();
     } else {
-      transactionBoxes[zone]!.add(name);
+      final boxes = transactionBoxes[zone];
+      if (boxes == null) {
+        throw StateError('Transaction zone has no box set.');
+      }
+      boxes.add(name);
     }
   }
 

--- a/hive/lib/src/box_collection/box_collection.dart
+++ b/hive/lib/src/box_collection/box_collection.dart
@@ -244,11 +244,11 @@ class CollectionBox<V> implements implementation.CollectionBox<V> {
     if (zone == null) {
       await flush();
     } else {
-      final boxes = transactionBoxes[zone];
-      if (boxes == null) {
+      final transactionBoxes = CollectionBox.transactionBoxes[zone];
+      if (transactionBoxes == null) {
         throw StateError('Transaction zone has no box set.');
       }
-      boxes.add(name);
+      transactionBoxes.add(name);
     }
   }
 

--- a/hive/lib/src/io/buffered_file_reader.dart
+++ b/hive/lib/src/io/buffered_file_reader.dart
@@ -11,11 +11,8 @@ class BufferedFileReader {
   static const defaultChunkSize = 1000 * 64;
 
   /// Not part of public API
-  ///
-  /// Nullable because of testing. [loadBytes] can throw if the count is not in
-  /// the buffer.
   @visibleForTesting
-  final RandomAccessFile? file;
+  final RandomAccessFile file;
 
   /// Not part of public API
   @visibleForTesting
@@ -78,10 +75,6 @@ class BufferedFileReader {
       }
 
       _bufferOffset = 0;
-      final file = this.file;
-      if (file == null) {
-        throw StateError('BufferedFileReader has no file.');
-      }
       final readBytes = await file.readInto(buffer, remaining);
       _bufferSize = remaining + readBytes;
       _fileOffset += readBytes;

--- a/hive/lib/src/io/buffered_file_reader.dart
+++ b/hive/lib/src/io/buffered_file_reader.dart
@@ -78,11 +78,11 @@ class BufferedFileReader {
       }
 
       _bufferOffset = 0;
-      final raf = file;
-      if (raf == null) {
+      final file = this.file;
+      if (file == null) {
         throw StateError('BufferedFileReader has no file.');
       }
-      final readBytes = await raf.readInto(buffer, remaining);
+      final readBytes = await file.readInto(buffer, remaining);
       _bufferSize = remaining + readBytes;
       _fileOffset += readBytes;
 

--- a/hive/lib/src/io/buffered_file_reader.dart
+++ b/hive/lib/src/io/buffered_file_reader.dart
@@ -78,7 +78,11 @@ class BufferedFileReader {
       }
 
       _bufferOffset = 0;
-      final readBytes = await file!.readInto(buffer, remaining);
+      final raf = file;
+      if (raf == null) {
+        throw StateError('BufferedFileReader has no file.');
+      }
+      final readBytes = await raf.readInto(buffer, remaining);
       _bufferSize = remaining + readBytes;
       _fileOffset += readBytes;
 

--- a/hive/lib/src/isolate/isolated_hive_impl/impl/isolated_hive_impl_vm.dart
+++ b/hive/lib/src/isolate/isolated_hive_impl/impl/isolated_hive_impl_vm.dart
@@ -28,7 +28,13 @@ class IsolatedHiveImpl extends TypeRegistryImpl
   final _openingBoxes = <String, Future>{};
 
   @override
-  IsolateConnection get connection => _connection!;
+  IsolateConnection get connection {
+    final connection = _connection;
+    if (connection == null) {
+      throw HiveError('IsolatedHive is not initialized');
+    }
+    return connection;
+  }
 
   late Future<IsolateConnection> Function() _spawnHiveIsolate =
       () => spawnIsolate(

--- a/hive/lib/src/object/hive_list_impl.dart
+++ b/hive/lib/src/object/hive_list_impl.dart
@@ -40,7 +40,9 @@ class HiveListImpl<E extends HiveObjectMixin>
   /// Not part of public API
   HiveListImpl.lazy(this.boxName, List<dynamic>? keys) : _keys = keys;
 
-  /// The keys of a lazy list. Non-null whenever [_delegate] is null.
+  /// The keys backing a lazy list
+  ///
+  /// Only null if a delegate backed list has been disposed
   List<dynamic> get _lazyKeys {
     final keys = _keys;
     if (keys == null) {

--- a/hive/lib/src/object/hive_list_impl.dart
+++ b/hive/lib/src/object/hive_list_impl.dart
@@ -42,8 +42,7 @@ class HiveListImpl<E extends HiveObjectMixin>
 
   @override
   Iterable<dynamic> get keys {
-    final delegate = _delegate;
-    if (delegate == null) {
+    if (_delegate == null) {
       final keys = _keys;
       if (keys == null) {
         throw HiveError('HiveList has neither delegate nor keys.');

--- a/hive/lib/src/object/hive_list_impl.dart
+++ b/hive/lib/src/object/hive_list_impl.dart
@@ -56,20 +56,26 @@ class HiveListImpl<E extends HiveObjectMixin>
 
   @override
   Box get box {
-    final existing = _box;
-    if (existing != null) return existing;
-
-    final box = (_hive as HiveImpl).getBoxWithoutCheckInternal(boxName);
+    if (_box == null) {
+      final box = (_hive as HiveImpl).getBoxWithoutCheckInternal(boxName);
+      if (box == null) {
+        throw HiveError(
+          'To use this list, you have to open the box "$boxName" first.',
+        );
+      } else if (box is! Box) {
+        throw HiveError('The box "$boxName" is a lazy box. '
+            'You can only use HiveLists with normal boxes.');
+      } else {
+        _box = box;
+      }
+    }
+    final box = _box;
     if (box == null) {
       throw HiveError(
         'To use this list, you have to open the box "$boxName" first.',
       );
-    } else if (box is! Box) {
-      throw HiveError('The box "$boxName" is a lazy box. '
-          'You can only use HiveLists with normal boxes.');
-    } else {
-      return _box = box;
     }
+    return box;
   }
 
   @override

--- a/hive/lib/src/object/hive_list_impl.dart
+++ b/hive/lib/src/object/hive_list_impl.dart
@@ -42,8 +42,13 @@ class HiveListImpl<E extends HiveObjectMixin>
 
   @override
   Iterable<dynamic> get keys {
-    if (_delegate == null) {
-      return _keys!;
+    final delegate = _delegate;
+    if (delegate == null) {
+      final keys = _keys;
+      if (keys == null) {
+        throw HiveError('HiveList has neither delegate nor keys.');
+      }
+      return keys;
     } else {
       return super.keys;
     }
@@ -51,20 +56,20 @@ class HiveListImpl<E extends HiveObjectMixin>
 
   @override
   Box get box {
-    if (_box == null) {
-      final box = (_hive as HiveImpl).getBoxWithoutCheckInternal(boxName);
-      if (box == null) {
-        throw HiveError(
-          'To use this list, you have to open the box "$boxName" first.',
-        );
-      } else if (box is! Box) {
-        throw HiveError('The box "$boxName" is a lazy box. '
-            'You can only use HiveLists with normal boxes.');
-      } else {
-        _box = box;
-      }
+    final existing = _box;
+    if (existing != null) return existing;
+
+    final box = (_hive as HiveImpl).getBoxWithoutCheckInternal(boxName);
+    if (box == null) {
+      throw HiveError(
+        'To use this list, you have to open the box "$boxName" first.',
+      );
+    } else if (box is! Box) {
+      throw HiveError('The box "$boxName" is a lazy box. '
+          'You can only use HiveLists with normal boxes.');
+    } else {
+      return _box = box;
     }
-    return _box!;
   }
 
   @override
@@ -73,18 +78,27 @@ class HiveListImpl<E extends HiveObjectMixin>
       throw HiveError('HiveList has already been disposed.');
     }
 
+    final delegate = _delegate;
     if (_invalidated) {
+      if (delegate == null) {
+        throw HiveError('HiveList is invalidated but has no delegate.');
+      }
       final retained = <E>[];
-      for (final obj in _delegate!) {
+      for (final obj in delegate) {
         if (obj.isInHiveList(this)) {
           retained.add(obj);
         }
       }
       _delegate = retained;
       _invalidated = false;
-    } else if (_delegate == null) {
+      return retained;
+    } else if (delegate == null) {
+      final keys = _keys;
+      if (keys == null) {
+        throw HiveError('HiveList has neither delegate nor keys.');
+      }
       final list = <E>[];
-      for (final key in _keys!) {
+      for (final key in keys) {
         if (box.containsKey(key)) {
           final obj = box.get(key) as E;
           obj.linkHiveList(this);
@@ -92,15 +106,17 @@ class HiveListImpl<E extends HiveObjectMixin>
         }
       }
       _delegate = list;
+      return list;
     }
 
-    return _delegate!;
+    return delegate;
   }
 
   @override
   void dispose() {
-    if (_delegate != null) {
-      for (final element in _delegate!) {
+    final delegate = _delegate;
+    if (delegate != null) {
+      for (final element in delegate) {
         element.unlinkHiveList(this);
       }
       _delegate = null;
@@ -161,8 +177,9 @@ class HiveListImpl<E extends HiveObjectMixin>
 
   @override
   HiveList<T> castHiveList<T extends HiveObjectMixin>() {
-    if (_delegate != null) {
-      return HiveListImpl(box, objects: _delegate!.cast());
+    final delegate = _delegate;
+    if (delegate != null) {
+      return HiveListImpl(box, objects: delegate.cast());
     } else {
       return HiveListImpl.lazy(boxName, _keys);
     }

--- a/hive/lib/src/object/hive_list_impl.dart
+++ b/hive/lib/src/object/hive_list_impl.dart
@@ -40,41 +40,33 @@ class HiveListImpl<E extends HiveObjectMixin>
   /// Not part of public API
   HiveListImpl.lazy(this.boxName, List<dynamic>? keys) : _keys = keys;
 
-  @override
-  Iterable<dynamic> get keys {
-    if (_delegate == null) {
-      final keys = _keys;
-      if (keys == null) {
-        throw HiveError('HiveList has neither delegate nor keys.');
-      }
-      return keys;
-    } else {
-      return super.keys;
+  /// The keys of a lazy list. Non-null whenever [_delegate] is null.
+  List<dynamic> get _lazyKeys {
+    final keys = _keys;
+    if (keys == null) {
+      throw HiveError('HiveList has neither delegate nor keys.');
     }
+    return keys;
   }
 
   @override
+  Iterable<dynamic> get keys => _delegate == null ? _lazyKeys : super.keys;
+
+  @override
   Box get box {
-    if (_box == null) {
-      final box = (_hive as HiveImpl).getBoxWithoutCheckInternal(boxName);
-      if (box == null) {
-        throw HiveError(
-          'To use this list, you have to open the box "$boxName" first.',
-        );
-      } else if (box is! Box) {
-        throw HiveError('The box "$boxName" is a lazy box. '
-            'You can only use HiveLists with normal boxes.');
-      } else {
-        _box = box;
-      }
-    }
     final box = _box;
-    if (box == null) {
+    if (box != null) return box;
+
+    final opened = (_hive as HiveImpl).getBoxWithoutCheckInternal(boxName);
+    if (opened == null) {
       throw HiveError(
         'To use this list, you have to open the box "$boxName" first.',
       );
+    } else if (opened is! Box) {
+      throw HiveError('The box "$boxName" is a lazy box. '
+          'You can only use HiveLists with normal boxes.');
     }
-    return box;
+    return _box = opened;
   }
 
   @override
@@ -84,34 +76,27 @@ class HiveListImpl<E extends HiveObjectMixin>
     }
 
     final delegate = _delegate;
-    if (_invalidated) {
-      if (delegate == null) {
-        throw HiveError('HiveList is invalidated but has no delegate.');
-      }
-      final retained = <E>[];
-      for (final obj in delegate) {
-        if (obj.isInHiveList(this)) {
-          retained.add(obj);
-        }
-      }
-      _delegate = retained;
-      _invalidated = false;
-      return retained;
-    } else if (delegate == null) {
-      final keys = _keys;
-      if (keys == null) {
-        throw HiveError('HiveList has neither delegate nor keys.');
-      }
+    if (delegate == null) {
       final list = <E>[];
-      for (final key in keys) {
+      for (final key in _lazyKeys) {
         if (box.containsKey(key)) {
           final obj = box.get(key) as E;
           obj.linkHiveList(this);
           list.add(obj);
         }
       }
-      _delegate = list;
-      return list;
+      return _delegate = list;
+    }
+
+    if (_invalidated) {
+      final retained = <E>[];
+      for (final obj in delegate) {
+        if (obj.isInHiveList(this)) {
+          retained.add(obj);
+        }
+      }
+      _invalidated = false;
+      return _delegate = retained;
     }
 
     return delegate;

--- a/hive/lib/src/object/hive_object.dart
+++ b/hive/lib/src/object/hive_object.dart
@@ -22,23 +22,24 @@ mixin HiveObjectMixin {
   /// not been added to a box yet.
   dynamic get key => _key;
 
-  void _requireInitialized() {
-    if (_box == null) {
+  BoxBase _requireInitialized() {
+    final box = _box;
+    if (box == null) {
       throw HiveError('This object is currently not in a box.');
     }
+    return box;
   }
 
   /// Persists this object.
   Future<void> save() {
-    _requireInitialized();
-    return _box!.put(_key, this);
+    return _requireInitialized().put(_key, this);
   }
 
   /// Deletes this object from the box it is stored in.
   Future<void> delete() async {
-    _requireInitialized();
-    await _box!.delete(_key);
-    if (_box?.lazy == true) {
+    final box = _requireInitialized();
+    await box.delete(_key);
+    if (box.lazy) {
       // Lazy boxes won't automatically dispose their HiveObjects
       dispose();
     }
@@ -49,9 +50,10 @@ mixin HiveObjectMixin {
   /// For lazy boxes this only checks if the key exists in the box and NOT
   /// whether this instance is actually stored in the box.
   bool get isInBox {
-    if (_box != null) {
-      if (_box!.lazy) {
-        return _box!.containsKey(_key);
+    final box = _box;
+    if (box != null) {
+      if (box.lazy) {
+        return box.containsKey(_key);
       } else {
         return true;
       }

--- a/hive/lib/src/object/hive_object_internal.dart
+++ b/hive/lib/src/object/hive_object_internal.dart
@@ -39,7 +39,10 @@ extension HiveObjectInternal on HiveObjectMixin {
 
   /// Not part of public API
   void unlinkHiveList(HiveList list) {
-    final currentIndex = _hiveLists[list]!;
+    final currentIndex = _hiveLists[list];
+    if (currentIndex == null) {
+      throw StateError('HiveList is not linked to this object.');
+    }
     final newIndex = _hiveLists[list] = currentIndex - 1;
     if (newIndex <= 0) {
       _hiveLists.remove(list);

--- a/hive/lib/src/registry/type_registry_impl.dart
+++ b/hive/lib/src/registry/type_registry_impl.dart
@@ -186,8 +186,8 @@ class TypeRegistryImpl implements TypeRegistry {
       }
 
       final existingResolvedAdapter = findAdapterForType<T>();
-      final existingTypeAdapter = existingResolvedAdapter?.adapter;
-      if (existingTypeAdapter != null) {
+      if (existingResolvedAdapter != null) {
+        final existingTypeAdapter = existingResolvedAdapter.adapter;
         final adapterTypeId = adapter.typeId;
         final existingAdapterTypeId = existingTypeAdapter.typeId;
 
@@ -198,7 +198,7 @@ class TypeRegistryImpl implements TypeRegistry {
               '${existingTypeAdapter.runtimeType} (typeId $existingAdapterTypeId)';
 
           if (override) {
-            _typeAdapters.remove(existingResolvedAdapter!.typeId);
+            _typeAdapters.remove(existingResolvedAdapter.typeId);
             Logger.d(
               'Removed existing adapter $existingAdapterTypeString for type $T '
               'and replaced with $adapterTypeString.',

--- a/hive/lib/src/util/indexable_skip_list.dart
+++ b/hive/lib/src/util/indexable_skip_list.dart
@@ -252,17 +252,7 @@ class _KeyIterator<K, V> extends _Iterator<K, V, K> {
   _KeyIterator(_Node<K?, V?> super.node);
 
   @override
-  K get current {
-    final node = this.node;
-    if (node == null) {
-      throw StateError('No current element');
-    }
-    final key = node.key;
-    if (key == null) {
-      throw StateError('No current key');
-    }
-    return key;
-  }
+  K get current => node?.key ?? (throw StateError('No current element'));
 }
 
 @immutable
@@ -279,17 +269,7 @@ class _ValueIterator<K, V> extends _Iterator<K, V, V> {
   _ValueIterator(_Node<K?, V?> super.node);
 
   @override
-  V get current {
-    final node = this.node;
-    if (node == null) {
-      throw StateError('No current element');
-    }
-    final value = node.value;
-    if (value == null) {
-      throw StateError('No current value');
-    }
-    return value;
-  }
+  V get current => node?.value ?? (throw StateError('No current element'));
 }
 
 @immutable

--- a/hive/lib/src/util/indexable_skip_list.dart
+++ b/hive/lib/src/util/indexable_skip_list.dart
@@ -246,12 +246,12 @@ abstract class _Iterator<K, V, E> implements Iterator<E> {
 
   @override
   bool moveNext() {
-    final current = node;
-    if (current == null) {
+    final node = this.node;
+    if (node == null) {
       throw StateError('No current element');
     }
-    final next = current.next[0];
-    node = next;
+    final next = node.next[0];
+    this.node = next;
     return next != null;
   }
 }
@@ -261,11 +261,11 @@ class _KeyIterator<K, V> extends _Iterator<K, V, K> {
 
   @override
   K get current {
-    final currentNode = node;
-    if (currentNode == null) {
+    final node = this.node;
+    if (node == null) {
       throw StateError('No current element');
     }
-    final key = currentNode.key;
+    final key = node.key;
     if (key == null) {
       throw StateError('No current key');
     }
@@ -288,11 +288,11 @@ class _ValueIterator<K, V> extends _Iterator<K, V, V> {
 
   @override
   V get current {
-    final currentNode = node;
-    if (currentNode == null) {
+    final node = this.node;
+    if (node == null) {
       throw StateError('No current element');
     }
-    final value = currentNode.value;
+    final value = node.value;
     if (value == null) {
       throw StateError('No current value');
     }

--- a/hive/lib/src/util/indexable_skip_list.dart
+++ b/hive/lib/src/util/indexable_skip_list.dart
@@ -245,15 +245,7 @@ abstract class _Iterator<K, V, E> implements Iterator<E> {
   _Iterator(this.node);
 
   @override
-  bool moveNext() {
-    final node = this.node;
-    if (node == null) {
-      throw StateError('No current element');
-    }
-    final next = node.next[0];
-    this.node = next;
-    return next != null;
-  }
+  bool moveNext() => (node = node?.next[0]) != null;
 }
 
 class _KeyIterator<K, V> extends _Iterator<K, V, K> {

--- a/hive/lib/src/util/indexable_skip_list.dart
+++ b/hive/lib/src/util/indexable_skip_list.dart
@@ -208,7 +208,11 @@ class IndexableSkipList<K, V> {
       }
     }
 
-    return node!;
+    final result = node;
+    if (result == null) {
+      throw StateError('Skip list is inconsistent.');
+    }
+    return result;
   }
 
   /// Not part of public API
@@ -242,14 +246,32 @@ abstract class _Iterator<K, V, E> implements Iterator<E> {
   _Iterator(this.node);
 
   @override
-  bool moveNext() => (node = node!.next[0]) != null;
+  bool moveNext() {
+    final current = node;
+    if (current == null) {
+      throw StateError('No current element');
+    }
+    final next = current.next[0];
+    node = next;
+    return next != null;
+  }
 }
 
 class _KeyIterator<K, V> extends _Iterator<K, V, K> {
   _KeyIterator(_Node<K?, V?> super.node);
 
   @override
-  K get current => node!.key!;
+  K get current {
+    final currentNode = node;
+    if (currentNode == null) {
+      throw StateError('No current element');
+    }
+    final key = currentNode.key;
+    if (key == null) {
+      throw StateError('No current key');
+    }
+    return key;
+  }
 }
 
 @immutable
@@ -266,7 +288,17 @@ class _ValueIterator<K, V> extends _Iterator<K, V, V> {
   _ValueIterator(_Node<K?, V?> super.node);
 
   @override
-  V get current => node!.value!;
+  V get current {
+    final currentNode = node;
+    if (currentNode == null) {
+      throw StateError('No current element');
+    }
+    final value = currentNode.value;
+    if (value == null) {
+      throw StateError('No current value');
+    }
+    return value;
+  }
 }
 
 @immutable

--- a/hive/lib/src/util/indexable_skip_list.dart
+++ b/hive/lib/src/util/indexable_skip_list.dart
@@ -208,11 +208,10 @@ class IndexableSkipList<K, V> {
       }
     }
 
-    final result = node;
-    if (result == null) {
+    if (node == null) {
       throw StateError('Skip list is inconsistent.');
     }
-    return result;
+    return node;
   }
 
   /// Not part of public API

--- a/hive/test/integration/date_time_adapter_upgrade.dart
+++ b/hive/test/integration/date_time_adapter_upgrade.dart
@@ -18,20 +18,20 @@ void main() {
       });
 
       test('uses DateTimeWithTimeZoneAdapter for writing new values', () {
-        final result = registry.findAdapterForValue(DateTime.timestamp())!;
-        expect(result, isNotNull);
+        final result = registry.findAdapterForValue(DateTime.timestamp());
+        if (result == null) fail('expected non-null adapter');
         expect(result.adapter, isA<DateTimeWithTimezoneAdapter>());
       });
 
       test('uses DateTimeWithTimeZoneAdapter for reading if typeId = 18', () {
-        final result = registry.findAdapterForTypeId(18)!;
-        expect(result, isNotNull);
+        final result = registry.findAdapterForTypeId(18);
+        if (result == null) fail('expected non-null adapter');
         expect(result.adapter, isA<DateTimeWithTimezoneAdapter>());
       });
 
       test('uses DateTimeAdapter for reading if typeId = 16', () {
-        final result = registry.findAdapterForTypeId(16)!;
-        expect(result, isNotNull);
+        final result = registry.findAdapterForTypeId(16);
+        if (result == null) fail('expected non-null adapter');
         expect(result.adapter, isA<DateTimeAdapter>());
       });
     });

--- a/hive/test/integration/date_time_adapter_upgrade.dart
+++ b/hive/test/integration/date_time_adapter_upgrade.dart
@@ -2,6 +2,8 @@ import 'package:hive_ce/src/adapters/date_time_adapter.dart';
 import 'package:hive_ce/src/registry/type_registry_impl.dart';
 import 'package:test/test.dart';
 
+import '../tests/common.dart';
+
 void main() {
   group('upgrading DateTimeAdapter to DateTimeWithTimeZoneAdapter', () {
     group('TypeRegistry', () {
@@ -18,20 +20,18 @@ void main() {
       });
 
       test('uses DateTimeWithTimeZoneAdapter for writing new values', () {
-        final result = registry.findAdapterForValue(DateTime.timestamp());
-        if (result == null) fail('expected non-null adapter');
+        final result =
+            expectNotNull(registry.findAdapterForValue(DateTime.timestamp()));
         expect(result.adapter, isA<DateTimeWithTimezoneAdapter>());
       });
 
       test('uses DateTimeWithTimeZoneAdapter for reading if typeId = 18', () {
-        final result = registry.findAdapterForTypeId(18);
-        if (result == null) fail('expected non-null adapter');
+        final result = expectNotNull(registry.findAdapterForTypeId(18));
         expect(result.adapter, isA<DateTimeWithTimezoneAdapter>());
       });
 
       test('uses DateTimeAdapter for reading if typeId = 16', () {
-        final result = registry.findAdapterForTypeId(16);
-        if (result == null) fail('expected non-null adapter');
+        final result = expectNotNull(registry.findAdapterForTypeId(16));
         expect(result.adapter, isA<DateTimeAdapter>());
       });
     });

--- a/hive/test/integration/hive_list_test.dart
+++ b/hive/test/integration/hive_list_test.dart
@@ -3,6 +3,7 @@ import 'package:hive_ce/src/hive_impl.dart';
 import 'package:hive_ce/src/object/hive_list_impl.dart';
 import 'package:test/test.dart';
 
+import '../tests/common.dart';
 import 'integration.dart';
 
 class _TestObject extends HiveObject {
@@ -49,8 +50,7 @@ void main() {
       obj.list = HiveListImpl(box.box as Box<_TestObject>);
       await box.put('obj', obj);
 
-      var list = obj.list;
-      if (list == null) fail('expected non-null list');
+      var list = expectNotNull(obj.list);
 
       for (var i = 0; i < 100; i++) {
         final element = _TestObject('element$i');
@@ -61,11 +61,8 @@ void main() {
       await obj.save();
 
       box = await hive.reopenBox(box);
-      final reloaded = await box.get('obj');
-      if (reloaded == null) fail('expected non-null obj');
-      obj = reloaded;
-      list = obj.list;
-      if (list == null) fail('expected non-null list');
+      obj = expectNotNull(await box.get('obj'));
+      list = expectNotNull(obj.list);
       (list as HiveListImpl).debugHive = hive.hive as HiveImpl;
 
       for (var i = 0; i < 100; i++) {

--- a/hive/test/integration/hive_list_test.dart
+++ b/hive/test/integration/hive_list_test.dart
@@ -49,30 +49,37 @@ void main() {
       obj.list = HiveListImpl(box.box as Box<_TestObject>);
       await box.put('obj', obj);
 
+      var list = obj.list;
+      if (list == null) fail('expected non-null list');
+
       for (var i = 0; i < 100; i++) {
         final element = _TestObject('element$i');
         await box.add(element);
-        obj.list!.add(element);
+        list.add(element);
       }
 
       await obj.save();
 
       box = await hive.reopenBox(box);
-      obj = (await box.get('obj'))!;
-      (obj.list as HiveListImpl).debugHive = hive.hive as HiveImpl;
+      final reloaded = await box.get('obj');
+      if (reloaded == null) fail('expected non-null obj');
+      obj = reloaded;
+      list = obj.list;
+      if (list == null) fail('expected non-null list');
+      (list as HiveListImpl).debugHive = hive.hive as HiveImpl;
 
       for (var i = 0; i < 100; i++) {
-        expect(obj.list![i].name, 'element$i');
+        expect(list[i].name, 'element$i');
       }
 
-      await obj.list![99].delete();
-      expect(obj.list!.length, 99);
+      await list[99].delete();
+      expect(list.length, 99);
 
-      await obj.list![50].delete();
-      expect(obj.list![50].name, 'element51');
+      await list[50].delete();
+      expect(list[50].name, 'element51');
 
-      await obj.list![0].delete();
-      expect(obj.list![0].name, 'element1');
+      await list[0].delete();
+      expect(list[0].name, 'element1');
     },
     timeout: longTimeout,
   );

--- a/hive/test/integration/recovery_test.dart
+++ b/hive/test/integration/recovery_test.dart
@@ -33,12 +33,8 @@ Future _performTest(bool lazy, {required TestType type}) async {
     final boxFile = File(path.join(dir.path, 'testbox$i.hive'));
     await boxFile.writeAsBytes(subBytes);
 
-    final subFrames = frames.takeWhile((f) {
-      final length = f.length;
-      if (length == null) fail('expected non-null length');
-      return f.offset + length <= i + 1;
-    });
-
+    final subFrames =
+        frames.takeWhile((f) => f.offset + expectNotNull(f.length) <= i + 1);
     final subKeystore = Keystore.debug(frames: subFrames);
     if (lazy) {
       final box = await hive.openLazyBox('testbox$i');

--- a/hive/test/integration/recovery_test.dart
+++ b/hive/test/integration/recovery_test.dart
@@ -33,7 +33,12 @@ Future _performTest(bool lazy, {required TestType type}) async {
     final boxFile = File(path.join(dir.path, 'testbox$i.hive'));
     await boxFile.writeAsBytes(subBytes);
 
-    final subFrames = frames.takeWhile((f) => f.offset + f.length! <= i + 1);
+    final subFrames = frames.takeWhile((f) {
+      final length = f.length;
+      if (length == null) fail('expected non-null length');
+      return f.offset + length <= i + 1;
+    });
+
     final subKeystore = Keystore.debug(frames: subFrames);
     if (lazy) {
       final box = await hive.openLazyBox('testbox$i');

--- a/hive/test/tests/backend/storage_backend_memory_test.dart
+++ b/hive/test/tests/backend/storage_backend_memory_test.dart
@@ -2,6 +2,7 @@ import 'dart:typed_data';
 
 import 'package:hive_ce/src/backend/storage_backend_memory.dart';
 import 'package:hive_ce/src/binary/frame.dart';
+import 'package:hive_ce/src/box/keystore.dart';
 import 'package:hive_ce/src/registry/type_registry_impl.dart';
 import 'package:test/test.dart';
 
@@ -24,7 +25,11 @@ void main() {
         final bytes = Uint8List.fromList([1, 2, 3, 4]);
         final backend = StorageBackendMemory(bytes, null, null);
         expect(
-          () => backend.initialize(TypeRegistryImpl.nullImpl, null, false),
+          () => backend.initialize(
+            TypeRegistryImpl.nullImpl,
+            Keystore.debug(),
+            false,
+          ),
           throwsHiveError(['Wrong checksum']),
         );
       });

--- a/hive/test/tests/backend/storage_backend_memory_test.dart
+++ b/hive/test/tests/backend/storage_backend_memory_test.dart
@@ -11,12 +11,12 @@ import '../common.dart';
 void main() {
   group('StorageBackendMemory', () {
     test('.path is null', () {
-      final backend = StorageBackendMemory(null, null, null);
+      final backend = StorageBackendMemory(Uint8List(0), null, null);
       expect(backend.path, null);
     });
 
     test('.supportsCompaction is false', () {
-      final backend = StorageBackendMemory(null, null, null);
+      final backend = StorageBackendMemory(Uint8List(0), null, null);
       expect(backend.supportsCompaction, false);
     });
 
@@ -36,7 +36,7 @@ void main() {
     });
 
     test('.readValue() throws UnsupportedError', () {
-      final backend = StorageBackendMemory(null, null, null);
+      final backend = StorageBackendMemory(Uint8List(0), null, null);
       expect(
         () => backend.readValue(Frame('key', 'val')),
         throwsUnsupportedError,
@@ -44,27 +44,27 @@ void main() {
     });
 
     test('.writeFrames() does nothing', () async {
-      final backend = StorageBackendMemory(null, null, null);
+      final backend = StorageBackendMemory(Uint8List(0), null, null);
       await backend.writeFrames([Frame('key', 'val')]);
     });
 
     test('.compact() throws UnsupportedError', () {
-      final backend = StorageBackendMemory(null, null, null);
+      final backend = StorageBackendMemory(Uint8List(0), null, null);
       expect(() => backend.compact([]), throwsUnsupportedError);
     });
 
     test('.clear() does nothing', () async {
-      final backend = StorageBackendMemory(null, null, null);
+      final backend = StorageBackendMemory(Uint8List(0), null, null);
       await backend.clear();
     });
 
     test('.close() does nothing', () async {
-      final backend = StorageBackendMemory(null, null, null);
+      final backend = StorageBackendMemory(Uint8List(0), null, null);
       await backend.close();
     });
 
     test('.deleteFromDisk() throws UnsupportedError', () {
-      final backend = StorageBackendMemory(null, null, null);
+      final backend = StorageBackendMemory(Uint8List(0), null, null);
       expect(backend.deleteFromDisk, throwsUnsupportedError);
     });
   });

--- a/hive/test/tests/backend/vm/read_write_sync_test.dart
+++ b/hive/test/tests/backend/vm/read_write_sync_test.dart
@@ -5,12 +5,12 @@ Future _asyncRead(
   ReadWriteSync rw,
   int id,
   List<String> history, {
-  bool? throwError = false,
+  bool throwError = false,
 }) {
   return rw.syncRead(() async {
     history.add('startread$id');
     await Future.delayed(Duration(milliseconds: 10));
-    if (throwError!) {
+    if (throwError) {
       throw 'error$id';
     }
     history.add('stopread$id');
@@ -21,12 +21,12 @@ Future _asyncWrite(
   ReadWriteSync rw,
   int id,
   List<String> history, {
-  bool? throwError = false,
+  bool throwError = false,
 }) {
   return rw.syncWrite(() async {
     history.add('startwrite$id');
     await Future.delayed(Duration(milliseconds: 10));
-    if (throwError!) {
+    if (throwError) {
       throw 'error$id';
     }
     history.add('stopwrite$id');
@@ -37,12 +37,12 @@ Future _asyncReadWrite(
   ReadWriteSync rw,
   int id,
   List<String> history, {
-  bool? throwError = false,
+  bool throwError = false,
 }) {
   return rw.syncReadWrite(() async {
     history.add('startreadwrite$id');
     await Future.delayed(Duration(milliseconds: 10));
-    if (throwError!) {
+    if (throwError) {
       throw 'error$id';
     }
     history.add('stopreadwrite$id');
@@ -53,7 +53,7 @@ typedef _Operation = Future Function(
   ReadWriteSync rw,
   int id,
   List<String> history, {
-  bool? throwError,
+  bool throwError,
 });
 
 Future _asyncOperation(

--- a/hive/test/tests/binary/binary_reader_test.dart
+++ b/hive/test/tests/binary/binary_reader_test.dart
@@ -389,10 +389,9 @@ void main() {
         for (var i = 0; i < frames.length; i++) {
           final frame = frames[i];
           final reader = BinaryReaderImpl(frameBytes[i], testRegistry);
-          expectFrame(
-            reader.readFrame(lazy: false, frameOffset: offset)!,
-            frame,
-          );
+          final read = reader.readFrame(lazy: false, frameOffset: offset);
+          if (read == null) fail('expected non-null frame');
+          expectFrame(read, frame);
           offset += frameBytes[i].length;
         }
       });
@@ -403,10 +402,9 @@ void main() {
         for (var i = 0; i < frames.length; i++) {
           final frame = frames[i];
           final reader = BinaryReaderImpl(frameBytes[i], testRegistry);
-          expectFrame(
-            reader.readFrame(lazy: true, frameOffset: offset)!,
-            frame.toLazy(),
-          );
+          final read = reader.readFrame(lazy: true, frameOffset: offset);
+          if (read == null) fail('expected non-null frame');
+          expectFrame(read, frame.toLazy());
           offset += frameBytes[i].length;
         }
       });
@@ -417,14 +415,13 @@ void main() {
         for (var i = 0; i < frames.length; i++) {
           final frame = frames[i];
           final reader = BinaryReaderImpl(frameBytesEncrypted[i], testRegistry);
-          expectFrame(
-            reader.readFrame(
-              lazy: false,
-              frameOffset: offset,
-              cipher: testCipher,
-            )!,
-            frame,
+          final read = reader.readFrame(
+            lazy: false,
+            frameOffset: offset,
+            cipher: testCipher,
           );
+          if (read == null) fail('expected non-null frame');
+          expectFrame(read, frame);
           offset += frameBytesEncrypted[i].length;
         }
       });
@@ -435,14 +432,13 @@ void main() {
         for (var i = 0; i < frames.length; i++) {
           final frame = frames[i];
           final reader = BinaryReaderImpl(frameBytesEncrypted[i], testRegistry);
-          expectFrame(
-            reader.readFrame(
-              lazy: true,
-              frameOffset: offset,
-              cipher: testCipher,
-            )!,
-            frame.toLazy(),
+          final read = reader.readFrame(
+            lazy: true,
+            frameOffset: offset,
+            cipher: testCipher,
           );
+          if (read == null) fail('expected non-null frame');
+          expectFrame(read, frame.toLazy());
           offset += frameBytesEncrypted[i].length;
         }
       });

--- a/hive/test/tests/binary/binary_reader_test.dart
+++ b/hive/test/tests/binary/binary_reader_test.dart
@@ -389,9 +389,9 @@ void main() {
         for (var i = 0; i < frames.length; i++) {
           final frame = frames[i];
           final reader = BinaryReaderImpl(frameBytes[i], testRegistry);
-          final read = reader.readFrame(lazy: false, frameOffset: offset);
-          if (read == null) fail('expected non-null frame');
-          expectFrame(read, frame);
+          final readFrame = reader.readFrame(lazy: false, frameOffset: offset);
+          if (readFrame == null) fail('expected non-null frame');
+          expectFrame(readFrame, frame);
           offset += frameBytes[i].length;
         }
       });
@@ -402,9 +402,9 @@ void main() {
         for (var i = 0; i < frames.length; i++) {
           final frame = frames[i];
           final reader = BinaryReaderImpl(frameBytes[i], testRegistry);
-          final read = reader.readFrame(lazy: true, frameOffset: offset);
-          if (read == null) fail('expected non-null frame');
-          expectFrame(read, frame.toLazy());
+          final readFrame = reader.readFrame(lazy: true, frameOffset: offset);
+          if (readFrame == null) fail('expected non-null frame');
+          expectFrame(readFrame, frame.toLazy());
           offset += frameBytes[i].length;
         }
       });
@@ -415,13 +415,13 @@ void main() {
         for (var i = 0; i < frames.length; i++) {
           final frame = frames[i];
           final reader = BinaryReaderImpl(frameBytesEncrypted[i], testRegistry);
-          final read = reader.readFrame(
+          final readFrame = reader.readFrame(
             lazy: false,
             frameOffset: offset,
             cipher: testCipher,
           );
-          if (read == null) fail('expected non-null frame');
-          expectFrame(read, frame);
+          if (readFrame == null) fail('expected non-null frame');
+          expectFrame(readFrame, frame);
           offset += frameBytesEncrypted[i].length;
         }
       });
@@ -432,13 +432,13 @@ void main() {
         for (var i = 0; i < frames.length; i++) {
           final frame = frames[i];
           final reader = BinaryReaderImpl(frameBytesEncrypted[i], testRegistry);
-          final read = reader.readFrame(
+          final readFrame = reader.readFrame(
             lazy: true,
             frameOffset: offset,
             cipher: testCipher,
           );
-          if (read == null) fail('expected non-null frame');
-          expectFrame(read, frame.toLazy());
+          if (readFrame == null) fail('expected non-null frame');
+          expectFrame(readFrame, frame.toLazy());
           offset += frameBytesEncrypted[i].length;
         }
       });

--- a/hive/test/tests/binary/binary_reader_test.dart
+++ b/hive/test/tests/binary/binary_reader_test.dart
@@ -389,8 +389,8 @@ void main() {
         for (var i = 0; i < frames.length; i++) {
           final frame = frames[i];
           final reader = BinaryReaderImpl(frameBytes[i], testRegistry);
-          final readFrame = reader.readFrame(lazy: false, frameOffset: offset);
-          if (readFrame == null) fail('expected non-null frame');
+          final readFrame =
+              expectNotNull(reader.readFrame(lazy: false, frameOffset: offset));
           expectFrame(readFrame, frame);
           offset += frameBytes[i].length;
         }
@@ -402,8 +402,8 @@ void main() {
         for (var i = 0; i < frames.length; i++) {
           final frame = frames[i];
           final reader = BinaryReaderImpl(frameBytes[i], testRegistry);
-          final readFrame = reader.readFrame(lazy: true, frameOffset: offset);
-          if (readFrame == null) fail('expected non-null frame');
+          final readFrame =
+              expectNotNull(reader.readFrame(lazy: true, frameOffset: offset));
           expectFrame(readFrame, frame.toLazy());
           offset += frameBytes[i].length;
         }
@@ -415,12 +415,13 @@ void main() {
         for (var i = 0; i < frames.length; i++) {
           final frame = frames[i];
           final reader = BinaryReaderImpl(frameBytesEncrypted[i], testRegistry);
-          final readFrame = reader.readFrame(
-            lazy: false,
-            frameOffset: offset,
-            cipher: testCipher,
+          final readFrame = expectNotNull(
+            reader.readFrame(
+              lazy: false,
+              frameOffset: offset,
+              cipher: testCipher,
+            ),
           );
-          if (readFrame == null) fail('expected non-null frame');
           expectFrame(readFrame, frame);
           offset += frameBytesEncrypted[i].length;
         }
@@ -432,12 +433,13 @@ void main() {
         for (var i = 0; i < frames.length; i++) {
           final frame = frames[i];
           final reader = BinaryReaderImpl(frameBytesEncrypted[i], testRegistry);
-          final readFrame = reader.readFrame(
-            lazy: true,
-            frameOffset: offset,
-            cipher: testCipher,
+          final readFrame = expectNotNull(
+            reader.readFrame(
+              lazy: true,
+              frameOffset: offset,
+              cipher: testCipher,
+            ),
           );
-          if (readFrame == null) fail('expected non-null frame');
           expectFrame(readFrame, frame.toLazy());
           offset += frameBytesEncrypted[i].length;
         }

--- a/hive/test/tests/binary/verbatim_frames_test.dart
+++ b/hive/test/tests/binary/verbatim_frames_test.dart
@@ -5,6 +5,7 @@ import 'package:hive_ce/src/binary/binary_writer_impl.dart';
 import 'package:hive_ce/src/binary/frame.dart';
 import 'package:test/test.dart';
 
+import '../common.dart';
 import '../frames.dart';
 
 void main() {
@@ -21,8 +22,8 @@ void main() {
 
       final verbatimReader =
           BinaryReaderImpl(verbatimWriter.toBytes(), testRegistry);
-      final decodedFrame = verbatimReader.readFrame(verbatim: true);
-      if (decodedFrame == null) fail('expected non-null frame');
+      final decodedFrame =
+          expectNotNull(verbatimReader.readFrame(verbatim: true));
 
       expect(decodedFrame.key, encodedFrame.key);
       expect(decodedFrame.value, encodedFrame.value);

--- a/hive/test/tests/binary/verbatim_frames_test.dart
+++ b/hive/test/tests/binary/verbatim_frames_test.dart
@@ -21,7 +21,8 @@ void main() {
 
       final verbatimReader =
           BinaryReaderImpl(verbatimWriter.toBytes(), testRegistry);
-      final decodedFrame = verbatimReader.readFrame(verbatim: true)!;
+      final decodedFrame = verbatimReader.readFrame(verbatim: true);
+      if (decodedFrame == null) fail('expected non-null frame');
 
       expect(decodedFrame.key, encodedFrame.key);
       expect(decodedFrame.value, encodedFrame.value);

--- a/hive/test/tests/common.dart
+++ b/hive/test/tests/common.dart
@@ -7,6 +7,10 @@ import 'package:mocktail/mocktail.dart';
 import 'package:path/path.dart' as path;
 import 'package:test/test.dart';
 
+/// Fails the test if [value] is null, otherwise returns it
+T expectNotNull<T extends Object>(T? value) =>
+    value ?? fail('Expected a non-null $T');
+
 Matcher hiveErrorPredicate(List<String> containing) => predicate(
       (e) {
         final message = e.toString().toLowerCase();

--- a/hive/test/tests/hive_impl_test.dart
+++ b/hive/test/tests/hive_impl_test.dart
@@ -40,12 +40,11 @@ void main() {
       expect(() => hive.init('MYPATH'), returnsNormally);
       expect(hive.homePath, 'MYPATH');
 
-      final dateTimeAdapter = hive.findAdapterForValue(DateTime.timestamp());
-      if (dateTimeAdapter == null) fail('expected non-null adapter');
+      final dateTimeAdapter =
+          expectNotNull(hive.findAdapterForValue(DateTime.timestamp()));
       expect(dateTimeAdapter.adapter, isA<DateTimeWithTimezoneAdapter>());
 
-      final typeIdAdapter = hive.findAdapterForTypeId(16);
-      if (typeIdAdapter == null) fail('expected non-null adapter');
+      final typeIdAdapter = expectNotNull(hive.findAdapterForTypeId(16));
       expect(typeIdAdapter.adapter, isA<DateTimeAdapter>());
     });
 
@@ -312,8 +311,7 @@ void main() {
 
         final box1 = await hive.openBox('testBox1');
         await box1.put('key', 'value');
-        final box1Path = box1.path;
-        if (box1Path == null) fail('expected non-null path');
+        final box1Path = expectNotNull(box1.path);
         final box1File = File(box1Path);
 
         await hive.deleteBoxFromDisk('testBox1');
@@ -328,8 +326,7 @@ void main() {
 
         final box1 = await hive.openBox('testBox1');
         await box1.put('key', 'value');
-        final path = box1.path;
-        if (path == null) fail('expected non-null path');
+        final path = expectNotNull(box1.path);
         await box1.close();
         final box1File = File(path);
 
@@ -352,14 +349,12 @@ void main() {
 
       final box1 = await hive.openBox('testBox1');
       await box1.put('key', 'value');
-      final box1Path = box1.path;
-      if (box1Path == null) fail('expected non-null path');
+      final box1Path = expectNotNull(box1.path);
       final box1File = File(box1Path);
 
       final box2 = await hive.openBox('testBox2');
       await box2.put('key', 'value');
-      final box2Path = box2.path;
-      if (box2Path == null) fail('expected non-null path');
+      final box2Path = expectNotNull(box2.path);
       final box2File = File(box2Path);
 
       await hive.deleteFromDisk();

--- a/hive/test/tests/hive_impl_test.dart
+++ b/hive/test/tests/hive_impl_test.dart
@@ -40,11 +40,13 @@ void main() {
       expect(() => hive.init('MYPATH'), returnsNormally);
       expect(hive.homePath, 'MYPATH');
 
-      expect(
-        hive.findAdapterForValue(DateTime.timestamp())!.adapter,
-        isA<DateTimeWithTimezoneAdapter>(),
-      );
-      expect(hive.findAdapterForTypeId(16)!.adapter, isA<DateTimeAdapter>());
+      final dateTimeAdapter = hive.findAdapterForValue(DateTime.timestamp());
+      if (dateTimeAdapter == null) fail('expected non-null adapter');
+      expect(dateTimeAdapter.adapter, isA<DateTimeWithTimezoneAdapter>());
+
+      final typeIdAdapter = hive.findAdapterForTypeId(16);
+      if (typeIdAdapter == null) fail('expected non-null adapter');
+      expect(typeIdAdapter.adapter, isA<DateTimeAdapter>());
     });
 
     group('.openBox()', () {
@@ -310,7 +312,9 @@ void main() {
 
         final box1 = await hive.openBox('testBox1');
         await box1.put('key', 'value');
-        final box1File = File(box1.path!);
+        final box1Path = box1.path;
+        if (box1Path == null) fail('expected non-null path');
+        final box1File = File(box1Path);
 
         await hive.deleteBoxFromDisk('testBox1');
         expect(await box1File.exists(), false);
@@ -324,7 +328,8 @@ void main() {
 
         final box1 = await hive.openBox('testBox1');
         await box1.put('key', 'value');
-        final path = box1.path!;
+        final path = box1.path;
+        if (path == null) fail('expected non-null path');
         await box1.close();
         final box1File = File(path);
 
@@ -347,11 +352,15 @@ void main() {
 
       final box1 = await hive.openBox('testBox1');
       await box1.put('key', 'value');
-      final box1File = File(box1.path!);
+      final box1Path = box1.path;
+      if (box1Path == null) fail('expected non-null path');
+      final box1File = File(box1Path);
 
       final box2 = await hive.openBox('testBox2');
       await box2.put('key', 'value');
-      final box2File = File(box1.path!);
+      final box2Path = box2.path;
+      if (box2Path == null) fail('expected non-null path');
+      final box2File = File(box2Path);
 
       await hive.deleteFromDisk();
       expect(await box1File.exists(), false);

--- a/hive/test/tests/io/buffered_file_reader_test.dart
+++ b/hive/test/tests/io/buffered_file_reader_test.dart
@@ -17,12 +17,14 @@ Future<BufferedFileReader> openReader(
 
 void main() {
   group('BufferedFileReader', () {
-    test('constructor creates buffer with correct size', () {
-      var reader = BufferedFileReader(null);
+    test('constructor creates buffer with correct size', () async {
+      var reader = await openReader([]);
       expect(reader.buffer.length, BufferedFileReader.defaultChunkSize);
+      await reader.file.close();
 
-      reader = BufferedFileReader(null, 10);
+      reader = await openReader([], 10);
       expect(reader.buffer.length, 10);
+      await reader.file.close();
     });
 
     group('.skip()', () {
@@ -40,9 +42,7 @@ void main() {
         expect(reader.remainingInBuffer, 0);
         expect(reader.offset, 5);
 
-        final file = reader.file;
-        if (file == null) fail('expected non-null file');
-        await file.close();
+        await reader.file.close();
       });
 
       test('fails if not enough bytes available', () async {
@@ -53,9 +53,7 @@ void main() {
 
         expect(() => reader.skip(4), throwsA(anything));
 
-        final file = reader.file;
-        if (file == null) fail('expected non-null file');
-        await file.close();
+        await reader.file.close();
       });
     });
 
@@ -71,9 +69,7 @@ void main() {
         expect(reader.viewBytes(3), [3, 4, 5]);
         expect(reader.offset, 5);
 
-        final file = reader.file;
-        if (file == null) fail('expected non-null file');
-        await file.close();
+        await reader.file.close();
       });
 
       test('fails if not enough bytes available', () async {
@@ -82,9 +78,7 @@ void main() {
 
         expect(() => reader.viewBytes(6), throwsA(anything));
 
-        final file = reader.file;
-        if (file == null) fail('expected non-null file');
-        await file.close();
+        await reader.file.close();
       });
     });
 
@@ -97,9 +91,7 @@ void main() {
         expect(reader.viewBytes(2), [1, 2]);
         expect(reader.viewBytes(1), [3]);
 
-        final file = reader.file;
-        if (file == null) fail('expected non-null file');
-        await file.close();
+        await reader.file.close();
       });
 
       test('increases the buffer if it is too small', () async {
@@ -110,9 +102,7 @@ void main() {
         expect(await reader.loadBytes(3), 3);
         expect(reader.viewBytes(3), [3, 4, 5]);
 
-        final file = reader.file;
-        if (file == null) fail('expected non-null file');
-        await file.close();
+        await reader.file.close();
       });
 
       test('copies unused bytes', () async {
@@ -126,9 +116,7 @@ void main() {
         expect(await reader.loadBytes(5), 4);
         expect(reader.viewBytes(3), [4, 5, 6]);
 
-        final file = reader.file;
-        if (file == null) fail('expected non-null file');
-        await file.close();
+        await reader.file.close();
       });
     });
   });

--- a/hive/test/tests/io/buffered_file_reader_test.dart
+++ b/hive/test/tests/io/buffered_file_reader_test.dart
@@ -40,7 +40,9 @@ void main() {
         expect(reader.remainingInBuffer, 0);
         expect(reader.offset, 5);
 
-        await reader.file!.close();
+        final file = reader.file;
+        if (file == null) fail('expected non-null file');
+        await file.close();
       });
 
       test('fails if not enough bytes available', () async {
@@ -51,7 +53,9 @@ void main() {
 
         expect(() => reader.skip(4), throwsA(anything));
 
-        await reader.file!.close();
+        final file = reader.file;
+        if (file == null) fail('expected non-null file');
+        await file.close();
       });
     });
 
@@ -67,7 +71,9 @@ void main() {
         expect(reader.viewBytes(3), [3, 4, 5]);
         expect(reader.offset, 5);
 
-        await reader.file!.close();
+        final file = reader.file;
+        if (file == null) fail('expected non-null file');
+        await file.close();
       });
 
       test('fails if not enough bytes available', () async {
@@ -76,7 +82,9 @@ void main() {
 
         expect(() => reader.viewBytes(6), throwsA(anything));
 
-        await reader.file!.close();
+        final file = reader.file;
+        if (file == null) fail('expected non-null file');
+        await file.close();
       });
     });
 
@@ -89,7 +97,9 @@ void main() {
         expect(reader.viewBytes(2), [1, 2]);
         expect(reader.viewBytes(1), [3]);
 
-        await reader.file!.close();
+        final file = reader.file;
+        if (file == null) fail('expected non-null file');
+        await file.close();
       });
 
       test('increases the buffer if it is too small', () async {
@@ -100,7 +110,9 @@ void main() {
         expect(await reader.loadBytes(3), 3);
         expect(reader.viewBytes(3), [3, 4, 5]);
 
-        await reader.file!.close();
+        final file = reader.file;
+        if (file == null) fail('expected non-null file');
+        await file.close();
       });
 
       test('copies unused bytes', () async {
@@ -114,7 +126,9 @@ void main() {
         expect(await reader.loadBytes(5), 4);
         expect(reader.viewBytes(3), [4, 5, 6]);
 
-        await reader.file!.close();
+        final file = reader.file;
+        if (file == null) fail('expected non-null file');
+        await file.close();
       });
     });
   });

--- a/hive/test/tests/isolate/isolated_hive_test.dart
+++ b/hive/test/tests/isolate/isolated_hive_test.dart
@@ -311,7 +311,9 @@ void main() {
 
           final box1 = await hive.openBox('testBox1');
           await box1.put('key', 'value');
-          final box1File = File((await box1.path)!);
+          final box1Path = await box1.path;
+          if (box1Path == null) fail('expected non-null path');
+          final box1File = File(box1Path);
 
           await hive.deleteBoxFromDisk('testBox1');
           expect(await box1File.exists(), false);
@@ -323,7 +325,8 @@ void main() {
 
           final box1 = await hive.openBox('testBox1');
           await box1.put('key', 'value');
-          final path = (await box1.path)!;
+          final path = await box1.path;
+          if (path == null) fail('expected non-null path');
           await box1.close();
           final box1File = File(path);
 
@@ -347,11 +350,15 @@ void main() {
 
         final box1 = await hive.openBox('testBox1');
         await box1.put('key', 'value');
-        final box1File = File((await box1.path)!);
+        final box1Path = await box1.path;
+        if (box1Path == null) fail('expected non-null path');
+        final box1File = File(box1Path);
 
         final box2 = await hive.openBox('testBox2');
         await box2.put('key', 'value');
-        final box2File = File((await box2.path)!);
+        final box2Path = await box2.path;
+        if (box2Path == null) fail('expected non-null path');
+        final box2File = File(box2Path);
 
         await hive.deleteFromDisk();
         expect(await box1File.exists(), false);

--- a/hive/test/tests/isolate/isolated_hive_test.dart
+++ b/hive/test/tests/isolate/isolated_hive_test.dart
@@ -311,8 +311,7 @@ void main() {
 
           final box1 = await hive.openBox('testBox1');
           await box1.put('key', 'value');
-          final box1Path = await box1.path;
-          if (box1Path == null) fail('expected non-null path');
+          final box1Path = expectNotNull(await box1.path);
           final box1File = File(box1Path);
 
           await hive.deleteBoxFromDisk('testBox1');
@@ -325,8 +324,7 @@ void main() {
 
           final box1 = await hive.openBox('testBox1');
           await box1.put('key', 'value');
-          final path = await box1.path;
-          if (path == null) fail('expected non-null path');
+          final path = expectNotNull(await box1.path);
           await box1.close();
           final box1File = File(path);
 
@@ -350,14 +348,12 @@ void main() {
 
         final box1 = await hive.openBox('testBox1');
         await box1.put('key', 'value');
-        final box1Path = await box1.path;
-        if (box1Path == null) fail('expected non-null path');
+        final box1Path = expectNotNull(await box1.path);
         final box1File = File(box1Path);
 
         final box2 = await hive.openBox('testBox2');
         await box2.put('key', 'value');
-        final box2Path = await box2.path;
-        if (box2Path == null) fail('expected non-null path');
+        final box2Path = expectNotNull(await box2.path);
         final box2File = File(box2Path);
 
         await hive.deleteFromDisk();

--- a/hive/test/tests/registry/type_registry_impl_test.dart
+++ b/hive/test/tests/registry/type_registry_impl_test.dart
@@ -89,7 +89,8 @@ void main() {
         final adapter = TestAdapter();
         registry.registerAdapter(adapter);
 
-        final resolved = registry.findAdapterForValue(123)!;
+        final resolved = registry.findAdapterForValue(123);
+        if (resolved == null) fail('expected non-null adapter');
         expect(resolved.typeId, 32);
         expect(resolved.adapter, adapter);
       });
@@ -150,7 +151,8 @@ void main() {
             registry.registerAdapter(TestAdapter(100));
 
             final foundAdapter1 = registry.findAdapterForType<int>();
-            expect(foundAdapter1!.adapter.typeId, 100);
+            if (foundAdapter1 == null) fail('expected non-null adapter');
+            expect(foundAdapter1.adapter.typeId, 100);
 
             final output = await captureOutput(
               () => registry.registerAdapter(TestAdapter(200), override: true),
@@ -161,14 +163,16 @@ void main() {
             );
 
             final foundAdapter2 = registry.findAdapterForType<int>();
-            expect(foundAdapter2!.adapter.typeId, 200);
+            if (foundAdapter2 == null) fail('expected non-null adapter');
+            expect(foundAdapter2.adapter.typeId, 200);
           });
 
           test('internal', () async {
             final registry = TypeRegistryImpl();
 
             final foundAdapter1 = registry.findAdapterForType<Duration>();
-            expect(foundAdapter1!.adapter.typeId, 20);
+            if (foundAdapter1 == null) fail('expected non-null adapter');
+            expect(foundAdapter1.adapter.typeId, 20);
 
             final output = await captureOutput(
               () => registry.registerAdapter(
@@ -187,7 +191,8 @@ void main() {
             );
 
             final foundAdapter2 = registry.findAdapterForType<Duration>();
-            expect(foundAdapter2!.adapter.typeId, 60);
+            if (foundAdapter2 == null) fail('expected non-null adapter');
+            expect(foundAdapter2.adapter.typeId, 60);
           });
         });
       });
@@ -209,14 +214,16 @@ void main() {
         test('external', () {
           final registry = TypeRegistryImpl();
           registry.registerAdapter(TestAdapter(224));
-          final resolved = registry.findAdapterForValue(123)!;
+          final resolved = registry.findAdapterForValue(123);
+          if (resolved == null) fail('expected non-null adapter');
           expect(resolved.typeId, 320);
         });
 
         test('internal', () {
           final registry = TypeRegistryImpl();
           registry.registerAdapter(TestAdapter(32), internal: true);
-          final resolved = registry.findAdapterForValue(123)!;
+          final resolved = registry.findAdapterForValue(123);
+          if (resolved == null) fail('expected non-null adapter');
           expect(resolved.typeId, 256);
         });
       });
@@ -227,7 +234,8 @@ void main() {
       final adapter = TestAdapter();
       registry.registerAdapter(adapter);
 
-      final resolvedAdapter = registry.findAdapterForTypeId(32)!;
+      final resolvedAdapter = registry.findAdapterForTypeId(32);
+      if (resolvedAdapter == null) fail('expected non-null adapter');
       expect(resolvedAdapter.typeId, 32);
       expect(resolvedAdapter.adapter, adapter);
     });
@@ -238,7 +246,8 @@ void main() {
         final adapter = TestAdapter();
         registry.registerAdapter(adapter);
 
-        final resolvedAdapter = registry.findAdapterForValue(123)!;
+        final resolvedAdapter = registry.findAdapterForValue(123);
+        if (resolvedAdapter == null) fail('expected non-null adapter');
         expect(resolvedAdapter.typeId, 32);
         expect(resolvedAdapter.adapter, adapter);
       });
@@ -250,7 +259,8 @@ void main() {
         registry.registerAdapter(adapter1);
         registry.registerAdapter(adapter2);
 
-        final resolvedAdapter = registry.findAdapterForValue(123)!;
+        final resolvedAdapter = registry.findAdapterForValue(123);
+        if (resolvedAdapter == null) fail('expected non-null adapter');
         expect(resolvedAdapter.typeId, 32);
         expect(resolvedAdapter.adapter, adapter1);
       });
@@ -323,7 +333,8 @@ void main() {
       test('registers IgnoredTypeAdapter', () {
         final registry = TypeRegistryImpl();
         registry.ignoreTypeId(0);
-        final resolved = registry.findAdapterForTypeId(32)!;
+        final resolved = registry.findAdapterForTypeId(32);
+        if (resolved == null) fail('expected non-null adapter');
         expect(resolved.adapter is IgnoredTypeAdapter, true);
       });
 

--- a/hive/test/tests/registry/type_registry_impl_test.dart
+++ b/hive/test/tests/registry/type_registry_impl_test.dart
@@ -89,8 +89,7 @@ void main() {
         final adapter = TestAdapter();
         registry.registerAdapter(adapter);
 
-        final resolved = registry.findAdapterForValue(123);
-        if (resolved == null) fail('expected non-null adapter');
+        final resolved = expectNotNull(registry.findAdapterForValue(123));
         expect(resolved.typeId, 32);
         expect(resolved.adapter, adapter);
       });
@@ -150,8 +149,8 @@ void main() {
             final registry = TypeRegistryImpl();
             registry.registerAdapter(TestAdapter(100));
 
-            final foundAdapter1 = registry.findAdapterForType<int>();
-            if (foundAdapter1 == null) fail('expected non-null adapter');
+            final foundAdapter1 =
+                expectNotNull(registry.findAdapterForType<int>());
             expect(foundAdapter1.adapter.typeId, 100);
 
             final output = await captureOutput(
@@ -162,16 +161,16 @@ void main() {
               contains(contains('Removed existing adapter TestAdapter')),
             );
 
-            final foundAdapter2 = registry.findAdapterForType<int>();
-            if (foundAdapter2 == null) fail('expected non-null adapter');
+            final foundAdapter2 =
+                expectNotNull(registry.findAdapterForType<int>());
             expect(foundAdapter2.adapter.typeId, 200);
           });
 
           test('internal', () async {
             final registry = TypeRegistryImpl();
 
-            final foundAdapter1 = registry.findAdapterForType<Duration>();
-            if (foundAdapter1 == null) fail('expected non-null adapter');
+            final foundAdapter1 =
+                expectNotNull(registry.findAdapterForType<Duration>());
             expect(foundAdapter1.adapter.typeId, 20);
 
             final output = await captureOutput(
@@ -190,8 +189,8 @@ void main() {
               ),
             );
 
-            final foundAdapter2 = registry.findAdapterForType<Duration>();
-            if (foundAdapter2 == null) fail('expected non-null adapter');
+            final foundAdapter2 =
+                expectNotNull(registry.findAdapterForType<Duration>());
             expect(foundAdapter2.adapter.typeId, 60);
           });
         });
@@ -214,16 +213,14 @@ void main() {
         test('external', () {
           final registry = TypeRegistryImpl();
           registry.registerAdapter(TestAdapter(224));
-          final resolved = registry.findAdapterForValue(123);
-          if (resolved == null) fail('expected non-null adapter');
+          final resolved = expectNotNull(registry.findAdapterForValue(123));
           expect(resolved.typeId, 320);
         });
 
         test('internal', () {
           final registry = TypeRegistryImpl();
           registry.registerAdapter(TestAdapter(32), internal: true);
-          final resolved = registry.findAdapterForValue(123);
-          if (resolved == null) fail('expected non-null adapter');
+          final resolved = expectNotNull(registry.findAdapterForValue(123));
           expect(resolved.typeId, 256);
         });
       });
@@ -234,8 +231,7 @@ void main() {
       final adapter = TestAdapter();
       registry.registerAdapter(adapter);
 
-      final resolvedAdapter = registry.findAdapterForTypeId(32);
-      if (resolvedAdapter == null) fail('expected non-null adapter');
+      final resolvedAdapter = expectNotNull(registry.findAdapterForTypeId(32));
       expect(resolvedAdapter.typeId, 32);
       expect(resolvedAdapter.adapter, adapter);
     });
@@ -246,8 +242,8 @@ void main() {
         final adapter = TestAdapter();
         registry.registerAdapter(adapter);
 
-        final resolvedAdapter = registry.findAdapterForValue(123);
-        if (resolvedAdapter == null) fail('expected non-null adapter');
+        final resolvedAdapter =
+            expectNotNull(registry.findAdapterForValue(123));
         expect(resolvedAdapter.typeId, 32);
         expect(resolvedAdapter.adapter, adapter);
       });
@@ -259,8 +255,8 @@ void main() {
         registry.registerAdapter(adapter1);
         registry.registerAdapter(adapter2);
 
-        final resolvedAdapter = registry.findAdapterForValue(123);
-        if (resolvedAdapter == null) fail('expected non-null adapter');
+        final resolvedAdapter =
+            expectNotNull(registry.findAdapterForValue(123));
         expect(resolvedAdapter.typeId, 32);
         expect(resolvedAdapter.adapter, adapter1);
       });
@@ -333,8 +329,7 @@ void main() {
       test('registers IgnoredTypeAdapter', () {
         final registry = TypeRegistryImpl();
         registry.ignoreTypeId(0);
-        final resolved = registry.findAdapterForTypeId(32);
-        if (resolved == null) fail('expected non-null adapter');
+        final resolved = expectNotNull(registry.findAdapterForTypeId(32));
         expect(resolved.adapter is IgnoredTypeAdapter, true);
       });
 

--- a/hive_generator/analysis_options.yaml
+++ b/hive_generator/analysis_options.yaml
@@ -3,8 +3,3 @@ include: package:rexios_lints/dart/package_extra.yaml
 linter:
   rules:
     - require_trailing_commas
-
-plugins:
-  rexios_lints:
-    diagnostics:
-      not_null_assertion: false

--- a/hive_generator/lib/src/builder/registrar_intermediate_builder.dart
+++ b/hive_generator/lib/src/builder/registrar_intermediate_builder.dart
@@ -68,7 +68,11 @@ class RegistrarIntermediateBuilder implements Builder {
       final annotation = generateAdaptersAnnotationReaders.single;
       final revived = RevivedGenerateAdapters(annotation);
       for (final spec in revived.specs) {
-        adapters.add(generateAdapterName(spec.type.element!.displayName));
+        final element = spec.type.element;
+        if (element == null) {
+          throw 'AdapterSpec type has no element: ${spec.type}';
+        }
+        adapters.add(generateAdapterName(element.displayName));
       }
     } else {
       registrarLocation = false;

--- a/hive_generator/lib/src/builder/schema_migrator_builder.dart
+++ b/hive_generator/lib/src/builder/schema_migrator_builder.dart
@@ -57,7 +57,10 @@ class SchemaMigratorBuilder implements Builder {
       final cls = getClass(type.element);
       final className = cls.displayName;
 
-      final library = type.element.library!;
+      final library = type.element.library;
+      if (library == null) {
+        throw 'Element has no library: ${type.element.displayName}';
+      }
       final typeId = readTypeId(type.annotation);
       final result = TypeAdapterGenerator.getAccessors(
         typeId: typeId,

--- a/hive_generator/lib/src/generator/adapters_generator.dart
+++ b/hive_generator/lib/src/generator/adapters_generator.dart
@@ -52,15 +52,15 @@ class AdaptersGenerator extends GeneratorForAnnotation<GenerateAdapters> {
         .where((spec) => schema.types.containsKey(spec.type.getDisplayString()))
         .toList()
       ..sort((a, b) {
-        final aSchema = schema.types[a.type.getDisplayString()];
-        final bSchema = schema.types[b.type.getDisplayString()];
-        if (aSchema == null) {
+        final aTypeId = schema.types[a.type.getDisplayString()]?.typeId;
+        final bTypeId = schema.types[b.type.getDisplayString()]?.typeId;
+        if (aTypeId == null) {
           throw 'Missing schema type: ${a.type.getDisplayString()}';
         }
-        if (bSchema == null) {
+        if (bTypeId == null) {
           throw 'Missing schema type: ${b.type.getDisplayString()}';
         }
-        return aSchema.typeId.compareTo(bSchema.typeId);
+        return aTypeId.compareTo(bTypeId);
       });
 
     // Maintain order of new types

--- a/hive_generator/lib/src/generator/adapters_generator.dart
+++ b/hive_generator/lib/src/generator/adapters_generator.dart
@@ -47,21 +47,18 @@ class AdaptersGenerator extends GeneratorForAnnotation<GenerateAdapters> {
     }
     _validateSchema(schema);
 
+    int schemaTypeId(RevivedAdapterSpec spec) {
+      final name = spec.type.getDisplayString();
+      final type = schema.types[name];
+      if (type == null) throw 'Missing schema type: $name';
+      return type.typeId;
+    }
+
     // Sort existing types by type ID
     final existingSpecs = revived.specs
         .where((spec) => schema.types.containsKey(spec.type.getDisplayString()))
         .toList()
-      ..sort((a, b) {
-        final aTypeId = schema.types[a.type.getDisplayString()]?.typeId;
-        final bTypeId = schema.types[b.type.getDisplayString()]?.typeId;
-        if (aTypeId == null) {
-          throw 'Missing schema type: ${a.type.getDisplayString()}';
-        }
-        if (bTypeId == null) {
-          throw 'Missing schema type: ${b.type.getDisplayString()}';
-        }
-        return aTypeId.compareTo(bTypeId);
-      });
+      ..sort((a, b) => schemaTypeId(a).compareTo(schemaTypeId(b)));
 
     // Maintain order of new types
     final newSpecs = revived.specs

--- a/hive_generator/lib/src/generator/adapters_generator.dart
+++ b/hive_generator/lib/src/generator/adapters_generator.dart
@@ -52,9 +52,15 @@ class AdaptersGenerator extends GeneratorForAnnotation<GenerateAdapters> {
         .where((spec) => schema.types.containsKey(spec.type.getDisplayString()))
         .toList()
       ..sort((a, b) {
-        final aTypeId = schema.types[a.type.getDisplayString()]!.typeId;
-        final bTypeId = schema.types[b.type.getDisplayString()]!.typeId;
-        return aTypeId.compareTo(bTypeId);
+        final aSchema = schema.types[a.type.getDisplayString()];
+        final bSchema = schema.types[b.type.getDisplayString()];
+        if (aSchema == null) {
+          throw 'Missing schema type: ${a.type.getDisplayString()}';
+        }
+        if (bSchema == null) {
+          throw 'Missing schema type: ${b.type.getDisplayString()}';
+        }
+        return aSchema.typeId.compareTo(bSchema.typeId);
       });
 
     // Maintain order of new types
@@ -75,7 +81,11 @@ class AdaptersGenerator extends GeneratorForAnnotation<GenerateAdapters> {
     final newTypes = <String, HiveSchemaType>{};
     final content = StringBuffer();
     for (final spec in existingSpecs + newSpecs) {
-      final typeKey = spec.type.element!.displayName;
+      final element = spec.type.element;
+      if (element == null) {
+        throw 'AdapterSpec type has no element: ${spec.type}';
+      }
+      final typeKey = element.displayName;
 
       final schemaType = schema.types[typeKey] ??
           HiveSchemaType(
@@ -84,7 +94,7 @@ class AdaptersGenerator extends GeneratorForAnnotation<GenerateAdapters> {
             fields: {},
           );
       final result = TypeAdapterGenerator.generateTypeAdapter(
-        element: spec.type.element!,
+        element: element,
         library: library,
         typeId: schemaType.typeId,
         schema: schemaType,

--- a/hive_generator/lib/src/helper/helper.dart
+++ b/hive_generator/lib/src/helper/helper.dart
@@ -36,13 +36,11 @@ HiveFieldInfo? getHiveFieldAnn(Element? element) {
   final obj = _hiveFieldChecker.firstAnnotationOfExact(element);
   if (obj == null) return null;
 
-  final index = obj.getField('index');
+  final index = obj.getField('index')?.toIntValue();
   if (index == null) throw 'HiveField index is null.';
-  final indexValue = index.toIntValue();
-  if (indexValue == null) throw 'HiveField index is not an int.';
 
   return HiveFieldInfo(
-    indexValue,
+    index,
     obj.getField('defaultValue'),
   );
 }

--- a/hive_generator/lib/src/helper/helper.dart
+++ b/hive_generator/lib/src/helper/helper.dart
@@ -36,8 +36,13 @@ HiveFieldInfo? getHiveFieldAnn(Element? element) {
   final obj = _hiveFieldChecker.firstAnnotationOfExact(element);
   if (obj == null) return null;
 
+  final index = obj.getField('index');
+  if (index == null) throw 'HiveField index is null.';
+  final indexValue = index.toIntValue();
+  if (indexValue == null) throw 'HiveField index is not an int.';
+
   return HiveFieldInfo(
-    obj.getField('index')!.toIntValue()!,
+    indexValue,
     obj.getField('defaultValue'),
   );
 }

--- a/hive_generator/lib/src/helper/source_helper.dart
+++ b/hive_generator/lib/src/helper/source_helper.dart
@@ -26,7 +26,8 @@ String escapeDartString(String value) {
   var canBeRaw = true;
 
   value = value.replaceAllMapped(_escapeRegExp, (match) {
-    final value = match[0]!;
+    final value = match[0];
+    if (value == null) throw 'Unexpected empty regex match.';
     if (value == "'") {
       hasSingleQuote = true;
       return value;

--- a/hive_generator/lib/src/helper/type_helper.dart
+++ b/hive_generator/lib/src/helper/type_helper.dart
@@ -56,12 +56,8 @@ String literalToString(DartObject object, List<String> typeInformation) {
   } else if (object.type is FunctionType) {
     badType = 'Function';
   } else if (!reader.isLiteral) {
-    final type = object.type;
-    if (type == null) throwUnsupported('Unable to determine type.');
-    final element = type.element;
-    if (element == null) {
-      throwUnsupported('Unable to determine type element for `$type`.');
-    }
+    final element = object.type?.element;
+    if (element == null) throwUnsupported('Unable to determine type.');
     badType = element.displayName;
   }
 

--- a/hive_generator/lib/src/helper/type_helper.dart
+++ b/hive_generator/lib/src/helper/type_helper.dart
@@ -56,7 +56,13 @@ String literalToString(DartObject object, List<String> typeInformation) {
   } else if (object.type is FunctionType) {
     badType = 'Function';
   } else if (!reader.isLiteral) {
-    badType = object.type!.element!.displayName;
+    final type = object.type;
+    if (type == null) throwUnsupported('Unable to determine type.');
+    final element = type.element;
+    if (element == null) {
+      throwUnsupported('Unable to determine type element for `$type`.');
+    }
+    badType = element.displayName;
   }
 
   if (badType != null) {


### PR DESCRIPTION
## Summary

Drops the `not_null_assertion` suppression from `hive/analysis_options.yaml` and `hive_generator/analysis_options.yaml`, then removes every `!` null assertion the lint flags across both packages. This is intended to be a behavior-preserving cleanup.

Two approaches were used depending on the call site:

- **Tighten the API** where `null` was only ever passed by tests, so the assertion disappears rather than turning into a runtime check: `BufferedFileReader.file`, `StorageBackendMemory`'s `bytes` and `initialize`'s `keystore`, `FrameHelper.framesFromBytes`'s `keystore`, and `BackendManager.indexedDB` are all non-nullable now.
- **Check locally** everywhere else, throwing a descriptive `HiveError`/`StateError` instead of the bare `TypeError` an assertion would have produced. These paths were all unreachable before and remain unreachable; the only difference is a more useful message if one is ever hit.

Along the way, a few spots got tidied up: a private `Frame.requireLength` extension in `storage_backend_vm.dart` replaces four duplicated length checks, `_boxDirectory` in `vm/backend_manager.dart` deduplicates path normalization, `BoxCollection`'s transaction zone lookup returns the box set directly instead of a `Zone` that callers had to re-resolve, and tests share a new `expectNotNull` helper in `hive/test/tests/common.dart`.

## Behavior notes

- `_Iterator.moveNext` in `indexable_skip_list.dart` now returns `false` when called after exhaustion instead of throwing. This is the one deliberate runtime change. It only affects code that violates the `Iterator` contract by calling `moveNext` again after it returned `false`; `for-in`, `toList`, and spreads all stop at the first `false`.
- The `deleteFromDisk` test in `hive_impl_test.dart` had a pre-existing typo that built `box2File` from `box1.path`. Converting it to `expectNotNull(box2.path)` fixed the reference, so that assertion now actually covers box 2 for the first time. It passes.
- No exported signature in `hive.dart` changed, and no public API is affected.

## Test plan

- [x] `dart analyze --fatal-infos` clean on `hive` and `hive_generator`
- [x] `dart format --set-exit-if-changed` clean on both packages
- [x] `dart test` on `hive` (587 passing)
- [x] `dart test -p chrome --compiler dart2js` on `hive` (493 passing)
- [x] `dart test` on `hive_generator` (24 passing)
- [x] `build_runner build` on `hive_generator/example` produces byte-identical output