### PR TITLE
Point the inspector at hive_ce_flutter 3.0

### DIFF
--- a/hive_ce_inspector/pubspec.yaml
+++ b/hive_ce_inspector/pubspec.yaml
@@ -3,7 +3,7 @@ publish_to: none
 version: 1.0.0+1
 
 environment:
-  sdk: ^3.9.0
+  sdk: ^3.12.0
 
 dependencies:
   flutter:
@@ -19,12 +19,15 @@ dependencies:
 
 dev_dependencies:
   rexios_lints: ^19.0.0
-  hive_ce_flutter: ^2.3.2
+  hive_ce_flutter: ^3.0.0
+  material_ui: ^1.0.0
   test: ^1.26.3
 
 dependency_overrides:
   hive_ce:
     path: ../hive
+  hive_ce_flutter:
+    path: ../hive_flutter
 
 flutter:
   uses-material-design: true

--- a/hive_ce_inspector/test/binary/raw_object_reader_test.dart
+++ b/hive_ce_inspector/test/binary/raw_object_reader_test.dart
@@ -1,9 +1,11 @@
-import 'package:flutter/material.dart';
+import 'dart:ui' show Color;
+
 import 'package:hive_ce/src/binary/raw_object_reader.dart';
 import 'package:hive_ce/src/binary/raw_object_writer.dart';
 import 'package:hive_ce/src/registry/type_registry_impl.dart';
 import 'package:hive_ce_flutter/adapters.dart';
 import 'package:hive_ce_inspector/util/base_schema.dart';
+import 'package:material_ui/material_ui.dart' show TimeOfDay;
 import 'package:test/test.dart';
 
 void main() {


### PR DESCRIPTION
## Summary
- Depend on unpublished `hive_ce_flutter` 3.0 via path override
- Import `TimeOfDay` from `package:material_ui` in the adapter round-trip test
- Upgrade `rexios_lints` to 19 and disable `migrate_design_widgets` (DevTools still hosts SDK Material)

## Test plan
- [ ] `flutter test` in `hive_ce_inspector`
- [ ] `dart analyze --fatal-infos` in `hive_ce_inspector` on Dart 3.13 / Flutter 3.47

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>