### PR TITLE
Stop a failed box open leaking its error into the zone

### DIFF
--- a/hive/lib/src/box/box_base_impl.dart
+++ b/hive/lib/src/box/box_base_impl.dart
@@ -181,7 +181,7 @@ abstract class BoxBaseImpl<E> implements BoxBase<E>, InspectableBox {
 
     _open = false;
     await keystore.close();
-    hive.unregisterBox(name);
+    hive.unregisterBox(name, this);
     HiveConnect.unregisterBox(this);
 
     await backend.close();
@@ -192,7 +192,7 @@ abstract class BoxBaseImpl<E> implements BoxBase<E>, InspectableBox {
     if (_open) {
       _open = false;
       await keystore.close();
-      hive.unregisterBox(name);
+      hive.unregisterBox(name, this);
     }
 
     await backend.deleteFromDisk();

--- a/hive/lib/src/hive_impl.dart
+++ b/hive/lib/src/hive_impl.dart
@@ -260,8 +260,11 @@ class HiveImpl extends TypeRegistryImpl implements HiveInterface {
   }
 
   /// Not part of public API
-  void unregisterBox(String name) {
+  ///
+  /// [box] guards against a slow close deregistering the box that already replaced it under [name].
+  void unregisterBox(String name, [BoxBaseImpl? box]) {
     name = name.toLowerCase();
+    if (box != null && !identical(_boxes[name], box)) return;
     _boxes.remove(name);
   }
 

--- a/hive/lib/src/hive_impl.dart
+++ b/hive/lib/src/hive_impl.dart
@@ -262,7 +262,6 @@ class HiveImpl extends TypeRegistryImpl implements HiveInterface {
   /// Not part of public API
   void unregisterBox(String name) {
     name = name.toLowerCase();
-    _openingBoxes.remove(name);
     _boxes.remove(name);
   }
 

--- a/hive/test/tests/box/box_base_test.dart
+++ b/hive/test/tests/box/box_base_test.dart
@@ -391,7 +391,7 @@ void main() {
       await box.close();
       verifyInOrder([
         keystore.close,
-        () => hive.unregisterBox('myBox'),
+        () => hive.unregisterBox('myBox', box),
         backend.close,
       ]);
       expect(box.isOpen, false);
@@ -429,7 +429,7 @@ void main() {
         await box.deleteFromDisk();
         verifyInOrder([
           keystore.close,
-          () => hive.unregisterBox('myBox'),
+          () => hive.unregisterBox('myBox', box),
           backend.deleteFromDisk,
         ]);
         expect(box.isOpen, false);

--- a/hive/test/tests/hive_impl_test.dart
+++ b/hive/test/tests/hive_impl_test.dart
@@ -8,6 +8,7 @@ import 'dart:io';
 
 import 'package:hive_ce/hive_ce.dart';
 import 'package:hive_ce/src/adapters/date_time_adapter.dart';
+import 'package:hive_ce/src/box/box_base_impl.dart';
 import 'package:hive_ce/src/hive_impl.dart';
 import 'package:test/test.dart';
 
@@ -226,6 +227,22 @@ void main() {
           expect(caught, 2);
           expect(escaped, isEmpty);
         });
+      });
+
+      test('unregistering on behalf of another box leaves the live one alone',
+          () async {
+        final hive = await initHive();
+        final live = await hive.openBox<int>('live');
+        final other = await hive.openBox<int>('other');
+
+        hive.unregisterBox('live', other as BoxBaseImpl);
+
+        expect(hive.isBoxOpen('live'), isTrue);
+        expect(identical(hive.box<int>('live'), live), isTrue);
+
+        hive.unregisterBox('live', live as BoxBaseImpl);
+
+        expect(hive.isBoxOpen('live'), isFalse);
       });
     });
 

--- a/hive/test/tests/hive_impl_test.dart
+++ b/hive/test/tests/hive_impl_test.dart
@@ -3,6 +3,7 @@
 @TestOn('vm')
 library;
 
+import 'dart:async';
 import 'dart:io';
 
 import 'package:hive_ce/hive_ce.dart';
@@ -11,6 +12,26 @@ import 'package:hive_ce/src/hive_impl.dart';
 import 'package:test/test.dart';
 
 import 'common.dart';
+
+/// A value whose adapter writes fine but always refuses to read back, standing in for corrupt
+/// bytes or a format written by a newer build of an app.
+class _Undecodable {
+  const _Undecodable();
+}
+
+class _UndecodableAdapter extends TypeAdapter<_Undecodable> {
+  @override
+  final typeId = 0;
+
+  @override
+  _Undecodable read(BinaryReader reader) {
+    reader.readInt();
+    throw const FormatException('cannot decode this record');
+  }
+
+  @override
+  void write(BinaryWriter writer, _Undecodable obj) => writer.writeInt(1);
+}
 
 class _TestAdapter extends TypeAdapter<int> {
   const _TestAdapter([this.typeId = 0]);
@@ -143,6 +164,67 @@ void main() {
           await expectLater(openBox<Set<double>>(), completes);
           await expectLater(openBox<Set<bool>>(), completes);
           await expectLater(openBox<Set<String>>(), completes);
+        });
+      });
+
+      group('open failure', () {
+        test('a failed open does not leak its error to the zone', () async {
+          final hive = await initHive();
+          hive.registerAdapter(_UndecodableAdapter());
+          final box = await hive.openBox<_Undecodable>('undecodable');
+          await box.put('key', const _Undecodable());
+          await hive.close();
+
+          var caught = 0;
+          final escaped = <Object>[];
+          await runZonedGuarded(
+            () async {
+              try {
+                await hive.openBox<_Undecodable>('undecodable');
+              } on FormatException {
+                caught++;
+              }
+              await pumpEventQueue();
+            },
+            (error, _) => escaped.add(error),
+          );
+
+          expect(caught, 1);
+          expect(escaped, isEmpty);
+        });
+
+        test('retrying a failed open does not leak its error to the zone',
+            () async {
+          final hive = await initHive();
+          hive.registerAdapter(_UndecodableAdapter());
+          final box = await hive.openBox<_Undecodable>('undecodable');
+          await box.put('key', const _Undecodable());
+          await hive.close();
+
+          var caught = 0;
+          final escaped = <Object>[];
+          await runZonedGuarded(
+            () async {
+              // Deliberately back to back, with no await in between. The first attempt's cleanup
+              // runs a microtask later, by which point the retry has already registered itself.
+              try {
+                await hive.openBox<_Undecodable>('undecodable');
+              } on FormatException {
+                caught++;
+              }
+              try {
+                await hive.openBox<_Undecodable>('undecodable');
+              } on FormatException {
+                caught++;
+              }
+              await pumpEventQueue();
+            },
+            (error, _) => escaped.add(error),
+          );
+
+          // Both callers were told, and nothing went anywhere else.
+          expect(caught, 2);
+          expect(escaped, isEmpty);
         });
       });
     });


### PR DESCRIPTION
Fixes #319.

When an `openBox` fails and you retry it right away, the retry's error arrives twice. Once at whoever awaited it, which is right, and once as an unhandled error in the zone, which isn't.

## What was going on

1. A failed open fires `newBox?.close().ignore()` and moves on without waiting.
2. `close()` awaits `keystore.close()` first, so `unregisterBox` lands a microtask later.
3. By then the retry has already put its own future in `_openingBoxes`.
4. The dead box removes it, so nobody is left to handle that future's error.

Prints on the failing run:

```text
[hive] finally found own future: true      <- attempt 1, fine
caller caught #1
[hive] unregisterBox(things) dropped opening future: true   <- eats attempt 2's future
[hive] finally found own future: false     <- attempt 2 has nothing to ignore
caller caught #2
escaped to zone = 1
```

That lines up with the issue: first attempt always clean, N attempts leak N-1, one microtask between the calls makes it disappear.

## The change

| Commit | What |
|---|---|
| `eca28ff` | the test, red on its own |
| `a701708` | stop `unregisterBox` clearing `_openingBoxes` |
| `10a08cc` | only unregister the box actually registered under that name |

The second one is a deleted line. `_openBox` already removes its own entry in a `finally`, on success and failure alike, so anything still sitting in `_openingBoxes` belongs to an open that's running right now. Clearing it there never did a useful job.

The third is a sibling of the same problem: a slow-closing box could deregister a live box that took its name in the meantime. I couldn't get that one to misbehave in a test, since `keystore.close()` is one microtask while a box open does real file work, so the ordering happens to land the right way. So I guarded it instead of trusting the timing.

Heads up: that guard also covers #319 on its own, because it returns early in exactly the failed-open case. So the two aren't independent fixes, they overlap.

## Tests

Three added in `hive_impl_test.dart`:

- one failed open leaks nothing, passes before the fix too, keeps the pair honest
- a retried failed open leaks nothing, the regression itself
- unregistering for a box that isn't the registered one leaves the live one alone

<details>
<summary>Red before, green after</summary>

At `eca28ff`, before the fix:

```text
HiveImpl .openBox() open failure a failed open does not leak its error to the zone   [ok]
HiveImpl .openBox() open failure retrying a failed open does not leak its error to the zone [E]
  Expected: empty
    Actual: [FormatException:FormatException: cannot decode this record]
```

At `a701708` and after, both pass.

</details>

The first commit is deliberately red so the bug shows up in history. CI builds the merge result rather than each commit, so the checks here should be green. Squash it into the second if you'd rather not have a red commit in the log.

Checked with `dart analyze --fatal-infos`, `dart format --set-exit-if-changed`, and 590 tests on the VM. Also ran `box_base_test` on chrome/dart2js, since the third commit touches code shared with web.