### PR TITLE
Let openBox skip records it cannot decode instead of failing outright

### DIFF
--- a/hive/lib/src/backend/js/native/backend_manager.dart
+++ b/hive/lib/src/backend/js/native/backend_manager.dart
@@ -4,6 +4,7 @@ import 'package:hive_ce/hive_ce.dart';
 import 'package:hive_ce/src/backend/js/native/storage_backend_js.dart';
 import 'package:hive_ce/src/backend/js/native/utils.dart';
 import 'package:hive_ce/src/backend/storage_backend.dart';
+import 'package:hive_ce/src/registry/type_registry_impl.dart';
 import 'package:hive_ce/src/util/logger.dart';
 import 'package:web/web.dart';
 
@@ -20,6 +21,7 @@ class BackendManager implements BackendManagerInterface {
     HiveCipher? cipher,
     int? keyCrc,
     String? collection,
+    UndecodableValueHandler? onUndecodableValue,
   ) async {
     // compatibility for old store format
     final databaseName = collection ?? name;
@@ -52,7 +54,13 @@ class BackendManager implements BackendManagerInterface {
 
     Logger.i('Got object store $objectStoreName in database $databaseName.');
 
-    return StorageBackendJs(db, cipher, objectStoreName);
+    return StorageBackendJs(
+      db,
+      cipher,
+      objectStoreName,
+      TypeRegistryImpl.nullImpl,
+      onUndecodableValue,
+    );
   }
 
   @override

--- a/hive/lib/src/backend/js/native/storage_backend_js.dart
+++ b/hive/lib/src/backend/js/native/storage_backend_js.dart
@@ -160,6 +160,21 @@ class StorageBackendJs extends StorageBackend {
     }
   }
 
+  /// Not part of public API
+  ///
+  /// Undecoded, so a caller can decode one value at a time.
+  @visibleForTesting
+  Future<List<JSAny?>> getRawValues({bool cursor = false}) async {
+    final store = getStore(false);
+
+    if (store.has('getAll') && !cursor) {
+      final result = await store.getAll(null).asFuture<JSArray>();
+      return result.toDart;
+    } else {
+      return store.iterate().map((e) => e.value).toList();
+    }
+  }
+
   @override
   Future<int> initialize(
     TypeRegistry registry,
@@ -170,11 +185,14 @@ class StorageBackendJs extends StorageBackend {
     _registry = registry;
     final keys = await getKeys();
     if (!lazy) {
-      var i = 0;
-      final values = await getValues();
-      for (final value in values) {
-        final key = keys[i++];
-        keystore.insert(Frame(key, value), notify: false);
+      // Decoded one value at a time. getValues() maps lazily, so a failure in there cannot be
+      // tied back to its key, and its iterator retries the same element afterwards.
+      final rawValues = await getRawValues();
+      for (var i = 0; i < keys.length && i < rawValues.length; i++) {
+        keystore.insert(
+          Frame(keys[i], decodeValue(rawValues[i])),
+          notify: false,
+        );
       }
     } else {
       for (final key in keys) {

--- a/hive/lib/src/backend/js/native/storage_backend_js.dart
+++ b/hive/lib/src/backend/js/native/storage_backend_js.dart
@@ -30,6 +30,7 @@ class StorageBackendJs extends StorageBackend {
   final String objectStoreName;
 
   TypeRegistry _registry;
+  final UndecodableValueHandler? _onUndecodableValue;
 
   /// Not part of public API
   StorageBackendJs(
@@ -37,6 +38,7 @@ class StorageBackendJs extends StorageBackend {
     this._cipher,
     this.objectStoreName, [
     this._registry = TypeRegistryImpl.nullImpl,
+    this._onUndecodableValue,
   ]);
 
   @override
@@ -162,7 +164,7 @@ class StorageBackendJs extends StorageBackend {
 
   /// Not part of public API
   ///
-  /// Undecoded, so a caller can decode one value at a time.
+  /// Undecoded, so a caller can decode one value at a time and survive a single bad record.
   @visibleForTesting
   Future<List<JSAny?>> getRawValues({bool cursor = false}) async {
     final store = getStore(false);
@@ -185,14 +187,20 @@ class StorageBackendJs extends StorageBackend {
     _registry = registry;
     final keys = await getKeys();
     if (!lazy) {
-      // Decoded one value at a time. getValues() maps lazily, so a failure in there cannot be
-      // tied back to its key, and its iterator retries the same element afterwards.
+      // Decoded per value rather than through getValues(), whose lazy map cannot report which
+      // record failed and retries the same one after a throw.
       final rawValues = await getRawValues();
       for (var i = 0; i < keys.length && i < rawValues.length; i++) {
-        keystore.insert(
-          Frame(keys[i], decodeValue(rawValues[i])),
-          notify: false,
-        );
+        final Object? value;
+        try {
+          value = decodeValue(rawValues[i]);
+        } catch (error, stackTrace) {
+          // An adapter can throw anything, so nothing narrower would be honest here.
+          if (_onUndecodableValue == null) rethrow;
+          _onUndecodableValue(keys[i], error, stackTrace);
+          continue;
+        }
+        keystore.insert(Frame(keys[i], value), notify: false);
       }
     } else {
       for (final key in keys) {

--- a/hive/lib/src/backend/storage_backend.dart
+++ b/hive/lib/src/backend/storage_backend.dart
@@ -56,6 +56,7 @@ abstract class BackendManagerInterface {
     HiveCipher? cipher,
     int? keyCrc,
     String? collection,
+    UndecodableValueHandler? onUndecodableValue,
   );
 
   /// Deletes database

--- a/hive/lib/src/backend/storage_backend_memory.dart
+++ b/hive/lib/src/backend/storage_backend_memory.dart
@@ -10,14 +10,19 @@ import 'package:hive_ce/src/box/keystore.dart';
 class StorageBackendMemory extends StorageBackend {
   final HiveCipher? _cipher;
   final int? _keyCrc;
+  final UndecodableValueHandler? _onUndecodableValue;
 
   final FrameHelper _frameHelper;
 
   Uint8List? _bytes;
 
   /// Not part of public API
-  StorageBackendMemory(Uint8List bytes, this._cipher, this._keyCrc)
-      : _bytes = bytes,
+  StorageBackendMemory(
+    Uint8List bytes,
+    this._cipher,
+    this._keyCrc, [
+    this._onUndecodableValue,
+  ])  : _bytes = bytes,
         _frameHelper = FrameHelper();
 
   @override
@@ -43,6 +48,7 @@ class StorageBackendMemory extends StorageBackend {
       registry,
       _cipher,
       _keyCrc,
+      onUndecodableValue: _onUndecodableValue,
     );
 
     if (recoveryOffset != -1) {

--- a/hive/lib/src/backend/stub/backend_manager.dart
+++ b/hive/lib/src/backend/stub/backend_manager.dart
@@ -19,6 +19,7 @@ class BackendManager implements BackendManagerInterface {
     HiveCipher? cipher,
     int? keyCrc,
     String? collection,
+    UndecodableValueHandler? onUndecodableValue,
   ) {
     throw UnimplementedError();
   }

--- a/hive/lib/src/backend/vm/backend_manager.dart
+++ b/hive/lib/src/backend/vm/backend_manager.dart
@@ -25,6 +25,7 @@ class BackendManager implements BackendManagerInterface {
     HiveCipher? cipher,
     int? keyCrc,
     String? collection,
+    UndecodableValueHandler? onUndecodableValue,
   ) async {
     if (path == null) {
       throw HiveError('You need to initialize Hive or '
@@ -46,8 +47,14 @@ class BackendManager implements BackendManagerInterface {
     final file = await findHiveFileAndCleanUp(name, path);
     final lockFile = File('$path$_delimiter$name.lock');
 
-    final backend =
-        StorageBackendVm(file, lockFile, crashRecovery, cipher, keyCrc);
+    final backend = StorageBackendVm(
+      file,
+      lockFile,
+      crashRecovery,
+      cipher,
+      keyCrc,
+      onUndecodableValue,
+    );
     await backend.open();
     return backend;
   }

--- a/hive/lib/src/backend/vm/storage_backend_vm.dart
+++ b/hive/lib/src/backend/vm/storage_backend_vm.dart
@@ -29,6 +29,7 @@ class StorageBackendVm extends StorageBackend {
   final bool _crashRecovery;
   final HiveCipher? _cipher;
   final int? _keyCrc;
+  final UndecodableValueHandler? _onUndecodableValue;
   final FrameIoHelper _frameHelper;
 
   final ReadWriteSync _sync;
@@ -65,8 +66,9 @@ class StorageBackendVm extends StorageBackend {
     this._lockFile,
     this._crashRecovery,
     this._cipher,
-    this._keyCrc,
-  )   : _frameHelper = FrameIoHelper(),
+    this._keyCrc, [
+    this._onUndecodableValue,
+  ])  : _frameHelper = FrameIoHelper(),
         _sync = ReadWriteSync();
 
   /// Not part of public API
@@ -77,8 +79,9 @@ class StorageBackendVm extends StorageBackend {
     this._cipher,
     this._keyCrc,
     this._frameHelper,
-    this._sync,
-  );
+    this._sync, [
+    this._onUndecodableValue,
+  ]);
 
   @override
   String get path => _file.path;
@@ -128,6 +131,7 @@ class StorageBackendVm extends StorageBackend {
         _cipher,
         _keyCrc,
         verbatim: isolated,
+        onUndecodableValue: _onUndecodableValue,
       );
     } else {
       recoveryOffset =

--- a/hive/lib/src/binary/binary_reader_impl.dart
+++ b/hive/lib/src/binary/binary_reader_impl.dart
@@ -266,6 +266,7 @@ class BinaryReaderImpl extends BinaryReader {
     bool lazy = false,
     int frameOffset = 0,
     bool verbatim = false,
+    UndecodableValueHandler? onUndecodableValue,
   }) {
     // frame length is stored on 4 bytes
     if (availableBytes < 4) return null;
@@ -312,16 +313,25 @@ class BinaryReaderImpl extends BinaryReader {
     Frame frame;
     final dynamic key = readKey();
 
-    if (availableBytes == 0) {
+    try {
+      if (availableBytes == 0) {
+        frame = Frame.deleted(key);
+      } else if (lazy) {
+        frame = Frame.lazy(key);
+      } else if (verbatim) {
+        frame = Frame(key, viewBytes(availableBytes));
+      } else if (cipher == null) {
+        frame = Frame(key, read());
+      } else {
+        frame = Frame(key, readEncrypted(cipher));
+      }
+    } catch (error, stackTrace) {
+      // An adapter can throw anything, so nothing narrower would be honest here.
+      if (onUndecodableValue == null) rethrow;
+      onUndecodableValue(key as Object, error, stackTrace);
+      // Reported as deleted so the keystore drops it. The tail below still winds the reader to
+      // the exact frame end, which is known because the length and crc were checked up front.
       frame = Frame.deleted(key);
-    } else if (lazy) {
-      frame = Frame.lazy(key);
-    } else if (verbatim) {
-      frame = Frame(key, viewBytes(availableBytes));
-    } else if (cipher == null) {
-      frame = Frame(key, read());
-    } else {
-      frame = Frame(key, readEncrypted(cipher));
     }
 
     frame

--- a/hive/lib/src/binary/frame_helper.dart
+++ b/hive/lib/src/binary/frame_helper.dart
@@ -14,6 +14,7 @@ class FrameHelper {
     HiveCipher? cipher,
     int? keyCrc, {
     bool verbatim = false,
+    UndecodableValueHandler? onUndecodableValue,
   }) {
     final reader = BinaryReaderImpl(bytes, registry);
 
@@ -26,6 +27,7 @@ class FrameHelper {
         lazy: false,
         frameOffset: frameOffset,
         verbatim: verbatim,
+        onUndecodableValue: onUndecodableValue,
       );
       if (frame == null) return frameOffset;
 

--- a/hive/lib/src/hive.dart
+++ b/hive/lib/src/hive.dart
@@ -88,6 +88,17 @@ abstract class HiveInterface implements TypeRegistry {
   void resetAdapters();
 }
 
+/// Called for every stored value that cannot be decoded while a box is opening.
+///
+/// Passing one to [HiveInterface.openBox] skips those records instead of failing the whole open.
+/// The [key] is handed over so the record can be logged, deleted or refetched. Throwing from here
+/// aborts the open, which is how a caller keeps hive's own errors fatal while skipping others.
+typedef UndecodableValueHandler = void Function(
+  Object key,
+  Object error,
+  StackTrace stackTrace,
+);
+
 ///
 typedef KeyComparator = int Function(dynamic key1, dynamic key2);
 

--- a/hive/lib/src/hive.dart
+++ b/hive/lib/src/hive.dart
@@ -29,6 +29,7 @@ abstract class HiveInterface implements TypeRegistry {
     String? path,
     Uint8List? bytes,
     String? collection,
+    UndecodableValueHandler? onUndecodableValue,
     @Deprecated('Use encryptionCipher instead') List<int>? encryptionKey,
   });
 

--- a/hive/lib/src/hive_impl.dart
+++ b/hive/lib/src/hive_impl.dart
@@ -73,6 +73,7 @@ class HiveImpl extends TypeRegistryImpl implements HiveInterface {
     String? path,
     Uint8List? bytes,
     String? collection,
+    UndecodableValueHandler? onUndecodableValue,
   ) async {
     assert(path == null || bytes == null);
     assert(
@@ -105,7 +106,12 @@ class HiveImpl extends TypeRegistryImpl implements HiveInterface {
       try {
         StorageBackend backend;
         if (bytes != null) {
-          backend = StorageBackendMemory(bytes, cipher, keyCrc);
+          backend = StorageBackendMemory(
+            bytes,
+            cipher,
+            keyCrc,
+            onUndecodableValue,
+          );
         } else {
           backend = await _manager.open(
             name,
@@ -114,6 +120,7 @@ class HiveImpl extends TypeRegistryImpl implements HiveInterface {
             cipher,
             keyCrc,
             collection,
+            onUndecodableValue,
           );
         }
 
@@ -166,6 +173,7 @@ class HiveImpl extends TypeRegistryImpl implements HiveInterface {
     String? path,
     Uint8List? bytes,
     String? collection,
+    UndecodableValueHandler? onUndecodableValue,
     @Deprecated('Use encryptionCipher instead') List<int>? encryptionKey,
   }) async {
     if (encryptionKey != null) {
@@ -182,6 +190,7 @@ class HiveImpl extends TypeRegistryImpl implements HiveInterface {
       path,
       bytes,
       collection,
+      onUndecodableValue,
     ) as Box<E>;
   }
 
@@ -211,6 +220,8 @@ class HiveImpl extends TypeRegistryImpl implements HiveInterface {
       path,
       null,
       collection,
+      // A lazy open only reads keys, so there is no value to fail on here.
+      null,
     ) as LazyBox<E>;
   }
 

--- a/hive/lib/src/io/frame_io_helper.dart
+++ b/hive/lib/src/io/frame_io_helper.dart
@@ -47,6 +47,7 @@ class FrameIoHelper extends FrameHelper {
     HiveCipher? cipher,
     int? keyCrc, {
     bool verbatim = false,
+    UndecodableValueHandler? onUndecodableValue,
   }) async {
     final bytes = await readFile(path);
     return framesFromBytes(
@@ -56,6 +57,7 @@ class FrameIoHelper extends FrameHelper {
       cipher,
       keyCrc,
       verbatim: verbatim,
+      onUndecodableValue: onUndecodableValue,
     );
   }
 }

--- a/hive/test/tests/backend/js/storage_backend_js_test.dart
+++ b/hive/test/tests/backend/js/storage_backend_js_test.dart
@@ -50,6 +50,36 @@ Future<IDBDatabase> _getDbWith(Map<String, Object?> content) async {
   return db;
 }
 
+/// A value whose adapter writes fine but refuses to read one particular record back.
+class _Flaky {
+  const _Flaky(this.id);
+  final String id;
+}
+
+class _FlakyAdapter extends TypeAdapter<_Flaky> {
+  @override
+  final typeId = 1;
+
+  @override
+  _Flaky read(BinaryReader reader) {
+    final id = reader.readString();
+    if (id == 'bad') throw const FormatException('cannot decode this record');
+    return _Flaky(id);
+  }
+
+  @override
+  void write(BinaryWriter writer, _Flaky obj) => writer.writeString(obj.id);
+}
+
+/// Seeds the store with values already encoded, so reading them back runs the adapter.
+Future<IDBDatabase> _getDbWithEncoded(Map<String, JSAny?> content) async {
+  final db = await _openDb();
+  final store = _getStore(db);
+  await store.clear().asFuture();
+  content.forEach((k, v) => store.put(v, k.toJS));
+  return db;
+}
+
 void main() async {
   _nullDatabase = await _openDb('nullTestBox');
   group('StorageBackendJs', () {
@@ -192,6 +222,58 @@ void main() async {
         final backend = _getBackend(db: db);
 
         expect(await backend.getValues(), [1, null, 3]);
+      });
+    });
+
+    group('.initialize() with undecodable values', () {
+      /// Registry plus an encoder that can produce records the adapter will refuse.
+      (TypeRegistryImpl, StorageBackendJs) flakySetup() {
+        final registry = TypeRegistryImpl();
+        registry.registerAdapter(_FlakyAdapter());
+        return (
+          registry,
+          StorageBackendJs(_nullDatabase, null, 'box', registry)
+        );
+      }
+
+      Future<IDBDatabase> seed(StorageBackendJs encoder) => _getDbWithEncoded({
+            'a': encoder.encodeValue(Frame('a', const _Flaky('a'))),
+            'b': encoder.encodeValue(Frame('b', const _Flaky('bad'))),
+            'c': encoder.encodeValue(Frame('c', const _Flaky('c'))),
+          });
+
+      test('without a handler the open still fails', () async {
+        final (registry, encoder) = flakySetup();
+        final db = await seed(encoder);
+        final backend = StorageBackendJs(db, null, 'box', registry);
+
+        await expectLater(
+          backend.initialize(
+            registry,
+            Keystore.debug(notifier: ChangeNotifier()),
+            false,
+          ),
+          throwsA(isA<FormatException>()),
+        );
+      });
+
+      test('with a handler the bad record is skipped and reported', () async {
+        final (registry, encoder) = flakySetup();
+        final db = await seed(encoder);
+        final reported = <Object>[];
+        final backend = StorageBackendJs(
+          db,
+          null,
+          'box',
+          registry,
+          (key, error, _) => reported.add(key),
+        );
+
+        final keystore = Keystore.debug(notifier: ChangeNotifier());
+        await backend.initialize(registry, keystore, false);
+
+        expect(reported, ['b']);
+        expect(keystore.getKeys(), ['a', 'c']);
       });
     });
 

--- a/hive/test/tests/hive_impl_test.dart
+++ b/hive/test/tests/hive_impl_test.dart
@@ -209,15 +209,20 @@ void main() {
 
         test('throwing from the handler aborts the open', () async {
           final hive = await seeded();
+          var called = 0;
 
           await expectLater(
             hive.openBox<_Flaky>(
               'flaky',
-              onUndecodableValue: (key, error, stackTrace) =>
-                  Error.throwWithStackTrace(error, stackTrace),
+              onUndecodableValue: (key, error, stackTrace) {
+                called++;
+                Error.throwWithStackTrace(error, stackTrace);
+              },
             ),
             throwsA(isA<FormatException>()),
           );
+          // Asserted so this cannot pass just because the open failed anyway.
+          expect(called, 1);
         });
 
         test('a clean box never calls the handler', () async {

--- a/hive/test/tests/hive_impl_test.dart
+++ b/hive/test/tests/hive_impl_test.dart
@@ -12,6 +12,27 @@ import 'package:test/test.dart';
 
 import 'common.dart';
 
+/// A value whose adapter writes fine but refuses to read one particular record back.
+class _Flaky {
+  const _Flaky(this.id);
+  final String id;
+}
+
+class _FlakyAdapter extends TypeAdapter<_Flaky> {
+  @override
+  final typeId = 1;
+
+  @override
+  _Flaky read(BinaryReader reader) {
+    final id = reader.readString();
+    if (id == 'bad') throw const FormatException('cannot decode this record');
+    return _Flaky(id);
+  }
+
+  @override
+  void write(BinaryWriter writer, _Flaky obj) => writer.writeString(obj.id);
+}
+
 class _TestAdapter extends TypeAdapter<int> {
   const _TestAdapter([this.typeId = 0]);
 
@@ -143,6 +164,77 @@ void main() {
           await expectLater(openBox<Set<double>>(), completes);
           await expectLater(openBox<Set<bool>>(), completes);
           await expectLater(openBox<Set<String>>(), completes);
+        });
+      });
+
+      group('undecodable values', () {
+        Future<HiveImpl> seeded() async {
+          final hive = await initHive();
+          hive.registerAdapter(_FlakyAdapter());
+          final box = await hive.openBox<_Flaky>('flaky');
+          await box.put('a', const _Flaky('a'));
+          await box.put('b', const _Flaky('bad'));
+          await box.put('c', const _Flaky('c'));
+          await hive.close();
+          return hive;
+        }
+
+        test('without a handler the open still fails, as before', () async {
+          final hive = await seeded();
+
+          await expectLater(
+            hive.openBox<_Flaky>('flaky'),
+            throwsA(isA<FormatException>()),
+          );
+        });
+
+        test('with a handler the bad record is skipped and reported', () async {
+          final hive = await seeded();
+          final reported = <Object>[];
+
+          final box = await hive.openBox<_Flaky>(
+            'flaky',
+            onUndecodableValue: (key, error, _) {
+              reported.add(key);
+              expect(error, isA<FormatException>());
+            },
+          );
+
+          expect(reported, ['b']);
+          expect(box.keys, ['a', 'c']);
+          expect(box.values.map((value) => value.id), ['a', 'c']);
+          // Dropped from the keystore entirely, not left behind as a null.
+          expect(box.containsKey('b'), isFalse);
+        });
+
+        test('throwing from the handler aborts the open', () async {
+          final hive = await seeded();
+
+          await expectLater(
+            hive.openBox<_Flaky>(
+              'flaky',
+              onUndecodableValue: (key, error, stackTrace) =>
+                  Error.throwWithStackTrace(error, stackTrace),
+            ),
+            throwsA(isA<FormatException>()),
+          );
+        });
+
+        test('a clean box never calls the handler', () async {
+          final hive = await initHive();
+          hive.registerAdapter(_FlakyAdapter());
+          final seed = await hive.openBox<_Flaky>('clean');
+          await seed.put('a', const _Flaky('a'));
+          await hive.close();
+
+          var called = 0;
+          final box = await hive.openBox<_Flaky>(
+            'clean',
+            onUndecodableValue: (_, __, ___) => called++,
+          );
+
+          expect(called, 0);
+          expect(box.keys, ['a']);
         });
       });
     });


### PR DESCRIPTION
Fixes #318.

Right now one record whose adapter throws takes the whole box with it. `openBox` decodes every value before the box exists, so one bad record means no box and nothing else in there is reachable.

This adds an opt-in way to skip that record and keep the rest.

```dart
final box = await Hive.openBox<Thing>(
  'things',
  onUndecodableValue: (key, error, stackTrace) {
    log('dropping $key: $error');
  },
);
```

Leave it off and nothing changes. Pass it and bad records are skipped, with the key handed to you so you can log it, delete it or refetch it.

Throwing from inside the handler aborts the open. So you can skip a `FormatException` and still let a `HiveError` be fatal. You need that split because a missing adapter registration and real corruption both surface as `unknown typeId`, and only your app knows which one it is. No second flag needed.

## How it works

`readFrame` reads the frame length and checks the crc before it touches the value, so a record that fails to decode is structurally fine and its end is already known. Wrapping only the value-decode branch and falling back to `Frame.deleted(key)` drops that key. The existing tail winds the reader to the exact frame end, so everything after it still decodes.

Web takes a different path with no frames at all, so the same wrap goes around its per-value decode.

## Not included, on purpose

| Left alone | Why |
|---|---|
| `openLazyBox` | a lazy open only reads keys, and a bad record already fails at `get`, scoped to that one key |
| `IsolatedHive` | it opens in verbatim mode and never runs adapters at open, so it was never affected |

Confirmed the second one rather than assumed it:

```text
verbatim:false -> THREW FormatException
verbatim:true  -> OK, keys=[a, b, c]
```

## Testing

Six new tests:

- four on the VM: no handler still throws, skip and report, throwing aborts, clean box never calls it
- two on web, built with `encodeValue` so the bytes really are undecodable

Since these cover a new parameter they can't be red beforehand, they wouldn't compile. So I broke the logic instead and checked the tests noticed.

<details>
<summary>What the mutations showed</summary>

| Broke this | Result |
|---|---|
| `readFrame` always rethrows | both VM skip tests fail |
| web loop always rethrows | web skip test fails |
| reverted the first commit | web test mis-attributes, `['b','c']` instead of `['b']` |

That last one bit me for real while writing it. `List.map`'s iterator sets its current value before bumping the index, so a throwing element gets retried and the failure lands on the wrong key. That's why the first commit exists.

One test passed under mutation at first, because when everything rethrows the open fails anyway. `f1e25719` makes it count handler calls so it fails properly.

</details>

Ran 591 tests on the VM and 495 on chrome under both dart2js and dart2wasm. `dart analyze --fatal-infos` and `dart format --set-exit-if-changed` clean here and in `hive_flutter`, `hive_generator` and `hive_ce_inspector`. Also checked a lazy `get` on a bad record still throws, so the handler doesn't leak into the read path.

## Needs more consideration

1. `StorageBackendJs` has grown a fifth optional positional parameter, so the manager now passes `TypeRegistryImpl.nullImpl` explicitly. Named parameters would read better, but that's a wider change to an internal class. Happy to do it if you want.

2. `getValues(cursor: true)` dartifies instead of decoding. Pre-existing and untouched, but my `getRawValues` sits next to it and makes the difference easier to spot. Looks like its own bug.